### PR TITLE
Move all RPC calls to single client that chooses WS/HTTP

### DIFF
--- a/config.md
+++ b/config.md
@@ -82,6 +82,7 @@
 |maxIdleConnsPerHost|The max number of idle connections, per unique hostname. Zero means net/http uses the default of only 2.|`int`|`100`
 |passthroughHeadersEnabled|Enable passing through the set of allowed HTTP request headers|`boolean`|`false`
 |requestTimeout|The maximum amount of time that a request is allowed to remain open|[`time.Duration`](https://pkg.go.dev/time#Duration)|`30s`
+|rpcRoutingMode|Which connection JSON/RPC calls are made on when a WebSocket is enabled. 'auto' routes node-sticky chain queries (blocks, logs, filters, receipts) to the WebSocket and stateless calls (submission, gas, balance) to the HTTP connection pool. 'ws' routes everything to the WebSocket. 'http' routes everything to the HTTP connection pool, leaving the WebSocket to carry only the newHeads subscription. 'legacy' reproduces the routing used before this setting existed, where only the block listener used the WebSocket|http,ws,auto,legacy|`auto`
 |tlsHandshakeTimeout|The maximum amount of time to wait for a successful TLS handshake|[`time.Duration`](https://pkg.go.dev/time#Duration)|`10s`
 |traceTXForRevertReason|Enable the use of transaction trace functions (e.g. debug_traceTransaction) to obtain transaction revert reasons. This can place a high load on the EVM client.|`boolean`|`false`
 |txCacheSize|Maximum of transactions to hold in the transaction info cache|`int`|`250`

--- a/internal/ethereum/config.go
+++ b/internal/ethereum/config.go
@@ -19,6 +19,7 @@ package ethereum
 import (
 	"github.com/hyperledger-firefly/common/pkg/config"
 	"github.com/hyperledger-firefly/common/pkg/wsclient"
+	"github.com/hyperledger-firefly/evmconnect/pkg/ethrpc"
 	"github.com/hyperledger-firefly/transaction-manager/pkg/ffcapi"
 )
 
@@ -51,6 +52,7 @@ const (
 	HederaCompatibilityMode       = "hederaCompatibilityMode"
 	TraceTXForRevertReason        = "traceTXForRevertReason"
 	WebSocketsEnabled             = "ws.enabled"
+	RPCRoutingMode                = "rpcRoutingMode"
 	MaxAsyncBlockFetchConcurrency = "maxAsyncBlockFetchConcurrency"
 	UseGetBlockReceipts           = "useGetBlockReceipts"
 )
@@ -72,6 +74,7 @@ const (
 func InitConfig(conf config.Section) {
 	wsclient.InitConfig(conf)
 	conf.AddKnownKey(WebSocketsEnabled, false)
+	conf.AddKnownKey(RPCRoutingMode, string(ethrpc.RoutingModeAuto))
 	conf.AddKnownKey(BlockCacheSize, 250)
 	conf.AddKnownKey(ReceiptCacheEnabled, false)
 	conf.AddKnownKey(ReceiptCacheSize, 5000)

--- a/internal/ethereum/estimate_gas.go
+++ b/internal/ethereum/estimate_gas.go
@@ -70,7 +70,7 @@ func (c *ethConnector) gasEstimate(ctx context.Context, tx *ethsigner.Transactio
 
 	// Do the gas estimation
 	var gasEstimate ethtypes.HexInteger
-	rpcErr := c.backend.CallRPC(ctx, &gasEstimate, "eth_estimateGas", tx)
+	rpcErr := c.rpc.CallRPC(ctx, &gasEstimate, "eth_estimateGas", tx)
 	if rpcErr != nil {
 		if reason, revertErr := c.attemptProcessingRevertData(ctx, errors, rpcErr); revertErr != nil {
 			return nil, reason, revertErr

--- a/internal/ethereum/ethereum.go
+++ b/internal/ethereum/ethereum.go
@@ -38,13 +38,11 @@ import (
 	"github.com/hyperledger-firefly/evmconnect/pkg/ethrpc"
 	"github.com/hyperledger-firefly/signer/pkg/abi"
 	"github.com/hyperledger-firefly/signer/pkg/ethtypes"
-	"github.com/hyperledger-firefly/signer/pkg/rpcbackend"
 	"github.com/hyperledger-firefly/transaction-manager/pkg/ffcapi"
 )
 
 type ethConnector struct {
-	backend           rpcbackend.Backend
-	wsBackend         rpcbackend.WebSocketRPCClient
+	rpc               ethrpc.Client
 	chainTrackingMode ffcapi.ChainTrackingMode
 
 	serializer                 *abi.Serializer
@@ -68,18 +66,48 @@ type ethConnector struct {
 type Connector interface {
 	ffcapi.API
 
-	// RPC returns the http JSON/RPC client
-	RPC() rpcbackend.RPC
-
-	// WSRPC returns the websocket JSON/RPC client
-	// NOTE: websocket client will be nil if websockets are not enabled
-	WSRPC() rpcbackend.WebSocketRPCClient
+	// RPC returns the JSON/RPC client used for everything the connector does. It owns both
+	// the HTTP connection pool and the WebSocket (when enabled), and routes each call to one
+	// of them based on the method name and the configured routing mode.
+	RPC() ethrpc.Client
 
 	// Get the high level block listener functionality, which provides a view of the head of the chain
 	BlockListener() ethblocklistener.BlockListener
 }
 
+// NewEthereumConnector builds the JSON/RPC client from configuration, and the connector over it.
 func NewEthereumConnector(ctx context.Context, conf config.Section) (cc Connector, err error) {
+	if conf.GetString(ffresty.HTTPConfigURL) == "" {
+		return nil, i18n.NewError(ctx, msgs.MsgMissingBackendURL)
+	}
+
+	var wsConf *wsclient.WSConfig
+	if conf.GetBool(WebSocketsEnabled) {
+		if wsConf, err = wsclient.GenerateConfig(ctx, conf); err != nil {
+			return nil, err
+		}
+	}
+	httpConf, err := ffresty.GenerateConfig(ctx, conf)
+	if err != nil {
+		return nil, err
+	}
+
+	rpc, err := ethrpc.NewClient(ctx, &ethrpc.Config{
+		RoutingMode:           ethrpc.RoutingMode(conf.GetString(RPCRoutingMode)),
+		HTTP:                  httpConf,
+		WS:                    wsConf,
+		MaxConcurrentRequests: conf.GetInt64(MaxConcurrentRequests),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return NewEthereumConnectorWithRPC(ctx, conf, rpc)
+}
+
+// NewEthereumConnectorWithRPC builds the connector over a pre-constructed JSON/RPC client.
+// The caller owns closing the client - see ethConnector.WaitClosed.
+func NewEthereumConnectorWithRPC(ctx context.Context, conf config.Section, rpc ethrpc.Client) (cc Connector, err error) {
 
 	chainTrackingMode := ffcapi.ChainTrackingMode(conf.GetString(ChainTrackingMode))
 	if chainTrackingMode == "" {
@@ -90,6 +118,7 @@ func NewEthereumConnector(ctx context.Context, conf config.Section) (cc Connecto
 	}
 
 	c := &ethConnector{
+		rpc:                        rpc,
 		eventStreams:               make(map[fftypes.UUID]*eventStream),
 		catchupPageSize:            conf.GetInt64(EventsCatchupPageSize),
 		catchupThreshold:           conf.GetInt64(EventsCatchupThreshold),
@@ -115,39 +144,11 @@ func NewEthereumConnector(ctx context.Context, conf config.Section) (cc Connecto
 		return nil, i18n.WrapError(ctx, err, msgs.MsgCacheInitFail, "transaction")
 	}
 
-	if conf.GetString(ffresty.HTTPConfigURL) == "" {
-		return nil, i18n.NewError(ctx, msgs.MsgMissingBackendURL)
-	}
 	c.gasEstimationFactor = big.NewFloat(conf.GetFloat64(ConfigGasEstimationFactor))
 
 	c.catchupDownscaleRegex, err = regexp.Compile(conf.GetString(EventsCatchupDownscaleRegex))
 	if err != nil {
 		return nil, i18n.WrapError(ctx, err, msgs.MsgInvalidRegex, c.catchupDownscaleRegex)
-	}
-
-	var wsConf *wsclient.WSConfig
-	var httpConf *ffresty.Config
-	if conf.GetBool(WebSocketsEnabled) {
-		// If websockets are enabled, then they are used selectively (block listening/query)
-		// not as a full replacement for HTTP.
-		wsConf, err = wsclient.GenerateConfig(ctx, conf)
-	}
-
-	if err == nil {
-		httpConf, err = ffresty.GenerateConfig(ctx, conf)
-	}
-
-	if err != nil {
-		return nil, err
-	}
-
-	httpClient := ffresty.NewWithConfig(ctx, *httpConf)
-	c.backend = rpcbackend.NewRPCClientWithOption(httpClient, rpcbackend.RPCClientOptions{
-		MaxConcurrentRequest: conf.GetInt64(MaxConcurrentRequests),
-	})
-
-	if wsConf != nil {
-		c.wsBackend = rpcbackend.NewWSRPCClient(wsConf)
 	}
 
 	c.serializer = abi.NewSerializer().SetByteSerializer(abi.HexByteSerializer0xPrefix)
@@ -169,7 +170,7 @@ func NewEthereumConnector(ctx context.Context, conf config.Section) (cc Connecto
 		return name
 	})
 
-	if c.blockListener, err = ethblocklistener.NewBlockListenerSupplyBackend(ctx, c.retry.Retry, &ethblocklistener.BlockListenerConfig{
+	if c.blockListener, err = ethblocklistener.NewBlockListener(ctx, c.retry.Retry, &ethblocklistener.BlockListenerConfig{
 		BlockPollingInterval:          conf.GetDuration(BlockPollingInterval),
 		MonitoredHeadLength:           int(c.checkpointBlockGap),
 		HederaCompatibilityMode:       conf.GetBool(HederaCompatibilityMode),
@@ -179,19 +180,15 @@ func NewEthereumConnector(ctx context.Context, conf config.Section) (cc Connecto
 		MaxAsyncBlockFetchConcurrency: conf.GetInt(MaxAsyncBlockFetchConcurrency),
 		UseGetBlockReceipts:           conf.GetBool(UseGetBlockReceipts),
 		ChainTrackingMode:             c.chainTrackingMode,
-	}, c.backend, c.wsBackend); err != nil {
+	}, c.rpc); err != nil {
 		return nil, err
 	}
 
 	return c, nil
 }
 
-func (c *ethConnector) RPC() rpcbackend.RPC {
-	return c.backend
-}
-
-func (c *ethConnector) WSRPC() rpcbackend.WebSocketRPCClient {
-	return c.wsBackend
+func (c *ethConnector) RPC() ethrpc.Client {
+	return c.rpc
 }
 
 func (c *ethConnector) BlockListener() ethblocklistener.BlockListener {
@@ -205,6 +202,9 @@ func (c *ethConnector) WaitClosed() {
 	}
 	for _, s := range c.eventStreams {
 		<-s.streamLoopDone
+	}
+	if c.rpc != nil {
+		c.rpc.Close()
 	}
 }
 

--- a/internal/ethereum/ethereum_test.go
+++ b/internal/ethereum/ethereum_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/hyperledger-firefly/evmconnect/pkg/ethblocklistener"
 	"github.com/hyperledger-firefly/evmconnect/pkg/ethrpc"
 	"github.com/hyperledger-firefly/signer/pkg/abi"
+	"github.com/hyperledger-firefly/signer/pkg/rpcbackend"
 	"github.com/hyperledger-firefly/transaction-manager/pkg/ffcapi"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -39,6 +40,12 @@ import (
 )
 
 func strPtr(s string) *string { return &s }
+
+func utRPC(t *testing.T, mRPC rpcbackend.RPC) ethrpc.Client {
+	rpc, err := ethrpc.NewClientWithBackends(t.Context(), ethrpc.RoutingModeHTTP, mRPC, nil)
+	require.NoError(t, err)
+	return rpc
+}
 
 func newTestConnector(t *testing.T, confSetup ...func(conf config.Section)) (context.Context, *ethConnector, *rpcbackendmocks.Backend, func()) {
 	ctx, c, mRPC, done := newTestConnectorWithNoBlockerFilterDefaultMocks(t, confSetup...)
@@ -64,13 +71,13 @@ func newTestConnectorWithNoBlockerFilterDefaultMocks(t *testing.T, confSetup ...
 		fn(conf)
 	}
 	ctx, done := context.WithCancel(context.Background())
-	cc, err := NewEthereumConnector(ctx, conf)
+	rpc, err := ethrpc.NewClientWithBackends(ctx, ethrpc.RoutingModeHTTP, mRPC, nil)
+	require.NoError(t, err)
+	cc, err := NewEthereumConnectorWithRPC(ctx, conf, rpc)
 	assert.NoError(t, err)
 	assert.NotNil(t, cc.RPC())
 
 	c := cc.(*ethConnector)
-	c.backend = mRPC
-	cc.BlockListener().UTSetBackend(mRPC)
 	return ctx, c, mRPC, func() {
 		done()
 		mRPC.AssertExpectations(t)
@@ -87,12 +94,17 @@ func TestConnectorInit(t *testing.T) {
 	cc, err := NewEthereumConnector(context.Background(), conf)
 	assert.Regexp(t, "FF23025", err)
 
+	conf.Set(ffresty.HTTPConfigURL, "http://localhost:8545")
 	conf.Set(ChainTrackingMode, "wrong")
 	_, err = NewEthereumConnector(context.Background(), conf)
 	assert.Regexp(t, "FF23069.*wrong", err)
 
+	conf.Set(RPCRoutingMode, "wrong")
+	_, err = NewEthereumConnector(context.Background(), conf)
+	assert.Regexp(t, "FF23075.*wrong", err)
+
+	conf.Set(RPCRoutingMode, ethrpc.RoutingModeAuto)
 	conf.Set(ChainTrackingMode, "")
-	conf.Set(ffresty.HTTPConfigURL, "http://localhost:8545")
 	conf.Set(WebSocketsEnabled, true)
 	conf.Set(EventsCatchupThreshold, 1)
 	conf.Set(EventsCatchupPageSize, 500)
@@ -237,7 +249,7 @@ func TestRetryDefaultsFor429(t *testing.T) {
 	cc, err := NewEthereumConnector(ctx, conf)
 	assert.NoError(t, err)
 	assert.NotNil(t, cc.RPC())
-	assert.Nil(t, cc.WSRPC())
+	assert.False(t, cc.RPC().HasWebSocket())
 	defer done()
 
 	// Start a simple HTTP server that always replies with 429 Too Many Requests

--- a/internal/ethereum/event_listener.go
+++ b/internal/ethereum/event_listener.go
@@ -240,8 +240,8 @@ func (l *listener) listenerCatchupLoop() {
 				}
 			} else {
 				log.L(ctx).Errorf("Failed to query block range fromBlock=%d toBlock=%d: %s", fromBlock, toBlock, err)
-				failCount++
 			}
+			failCount++ // for exponential backoff calculation
 			continue
 		}
 		log.L(ctx).Infof("Listener catchup fromBlock=%d toBlock=%d events=%d", fromBlock, toBlock, len(events))

--- a/internal/ethereum/event_stream.go
+++ b/internal/ethereum/event_stream.go
@@ -304,7 +304,7 @@ func (es *eventStream) leadGroupCatchup() bool {
 func (es *eventStream) uninstallFilter(filter *string) {
 	if *filter != "" {
 		var res bool
-		if err := es.c.backend.CallRPC(es.ctx, &res, "eth_uninstallFilter", filter); err != nil {
+		if err := es.c.rpc.CallRPC(es.ctx, &res, "eth_uninstallFilter", filter); err != nil {
 			log.L(es.ctx).Warnf("Error uninstalling filter '%v': %s", filter, err.Message)
 		} else {
 			log.L(es.ctx).Debugf("Uninstalled filter '%v': %t", filter, res)
@@ -368,7 +368,7 @@ func (es *eventStream) leadGroupSteadyState() bool {
 				}
 
 				// Create the new filter
-				err := es.c.backend.CallRPC(es.ctx, &filter, "eth_newFilter", &ethrpc.LogFilterJSONRPC{
+				err := es.c.rpc.CallRPC(es.ctx, &filter, "eth_newFilter", &ethrpc.LogFilterJSONRPC{
 					FromBlock: ethtypes.NewHexInteger64(fromBlock),
 					Topics: [][]ethtypes.HexBytes0xPrefix{
 						ag.signatureSet,
@@ -384,7 +384,7 @@ func (es *eventStream) leadGroupSteadyState() bool {
 			}
 			// Get the next batch of logs
 			var ethLogs []*ethrpc.LogJSONRPC
-			rpcErr := es.c.backend.CallRPC(es.ctx, &ethLogs, filterRPCMethodToUse, filter)
+			rpcErr := es.c.rpc.CallRPC(es.ctx, &ethLogs, filterRPCMethodToUse, filter)
 			// If we fail to query we just retry - setting filter to nil if not found
 			if rpcErr != nil {
 				if etherrors.MapError(etherrors.FilterRPCMethods, rpcErr.Error()) == ffcapi.ErrorReasonNotFound {
@@ -596,7 +596,7 @@ func (es *eventStream) getBlockRangeEvents(ctx context.Context, ag *aggregatedLi
 		logFilterJSONRPCReq.Address = []*ethtypes.Address0xHex{ag.listeners[0].config.filters[0].Address}
 	}
 
-	rpcErr := es.c.backend.CallRPC(ctx, &ethLogs, "eth_getLogs", logFilterJSONRPCReq)
+	rpcErr := es.c.rpc.CallRPC(ctx, &ethLogs, "eth_getLogs", logFilterJSONRPCReq)
 	if rpcErr != nil {
 		return nil, rpcErr.Error()
 	}

--- a/internal/ethereum/event_stream.go
+++ b/internal/ethereum/event_stream.go
@@ -304,7 +304,7 @@ func (es *eventStream) leadGroupCatchup() bool {
 func (es *eventStream) uninstallFilter(filter *string) {
 	if *filter != "" {
 		var res bool
-		if err := es.c.backend.CallRPC(es.ctx, &res, "eth_uninstallFilter", filter); err != nil {
+		if err := es.c.rpc.CallRPC(es.ctx, &res, "eth_uninstallFilter", filter); err != nil {
 			log.L(es.ctx).Warnf("Error uninstalling filter '%v': %s", filter, err.Message)
 		} else {
 			log.L(es.ctx).Debugf("Uninstalled filter '%v': %t", filter, res)
@@ -368,7 +368,7 @@ func (es *eventStream) leadGroupSteadyState() bool {
 				}
 
 				// Create the new filter
-				err := es.c.backend.CallRPC(es.ctx, &filter, "eth_newFilter", &ethrpc.LogFilterJSONRPC{
+				err := es.c.rpc.CallRPC(es.ctx, &filter, "eth_newFilter", &ethrpc.LogFilterJSONRPC{
 					FromBlock: ethtypes.NewHexInteger64(fromBlock),
 					Topics: [][]ethtypes.HexBytes0xPrefix{
 						ag.signatureSet,
@@ -384,7 +384,7 @@ func (es *eventStream) leadGroupSteadyState() bool {
 			}
 			// Get the next batch of logs
 			var ethLogs []*ethrpc.LogJSONRPC
-			rpcErr := es.c.backend.CallRPC(es.ctx, &ethLogs, filterRPCMethodToUse, filter)
+			rpcErr := es.c.rpc.CallRPC(es.ctx, &ethLogs, filterRPCMethodToUse, filter)
 			// If we fail to query we just retry - setting filter to nil if not found
 			if rpcErr != nil {
 				if etherrors.MapError(etherrors.FilterRPCMethods, rpcErr.Error()) == ffcapi.ErrorReasonNotFound {
@@ -593,7 +593,7 @@ func (es *eventStream) getBlockRangeEvents(ctx context.Context, ag *aggregatedLi
 		logFilterJSONRPCReq.Address = []*ethtypes.Address0xHex{ag.listeners[0].config.filters[0].Address}
 	}
 
-	rpcErr := es.c.backend.CallRPC(ctx, &ethLogs, "eth_getLogs", logFilterJSONRPCReq)
+	rpcErr := es.c.rpc.CallRPC(ctx, &ethLogs, "eth_getLogs", logFilterJSONRPCReq)
 	if rpcErr != nil {
 		return nil, rpcErr.Error()
 	}

--- a/internal/ethereum/event_stream_test.go
+++ b/internal/ethereum/event_stream_test.go
@@ -996,7 +996,7 @@ func TestStreamCleanupFilterOK(t *testing.T) {
 	es := &eventStream{
 		ctx: context.Background(),
 		c: &ethConnector{
-			backend: mRPC,
+			rpc: utRPC(t, mRPC),
 		},
 	}
 
@@ -1015,7 +1015,7 @@ func TestStreamCleanupFilterFailLog(t *testing.T) {
 	es := &eventStream{
 		ctx: context.Background(),
 		c: &ethConnector{
-			backend: mRPC,
+			rpc: utRPC(t, mRPC),
 		},
 	}
 

--- a/internal/ethereum/exec_query.go
+++ b/internal/ethereum/exec_query.go
@@ -91,7 +91,7 @@ func (c *ethConnector) callTransaction(ctx context.Context, tx *ethsigner.Transa
 	if blockNumber != nil {
 		blockNumberStr = *blockNumber
 	}
-	rpcErr := c.backend.CallRPC(ctx, &outputData, "eth_call", tx, blockNumberStr)
+	rpcErr := c.rpc.CallRPC(ctx, &outputData, "eth_call", tx, blockNumberStr)
 	if rpcErr != nil {
 		if reason, revertErr := c.attemptProcessingRevertData(ctx, errors, rpcErr); revertErr != nil {
 			return nil, reason, revertErr

--- a/internal/ethereum/get_address_balance.go
+++ b/internal/ethereum/get_address_balance.go
@@ -31,7 +31,7 @@ func (c *ethConnector) AddressBalance(ctx context.Context, req *ffcapi.AddressBa
 	if blockTag == "" {
 		blockTag = "latest"
 	}
-	rpcErr := c.backend.CallRPC(ctx, &addressBalance, "eth_getBalance", req.Address, blockTag)
+	rpcErr := c.rpc.CallRPC(ctx, &addressBalance, "eth_getBalance", req.Address, blockTag)
 	if rpcErr != nil {
 		return nil, "", rpcErr.Error()
 	}

--- a/internal/ethereum/get_gas_price.go
+++ b/internal/ethereum/get_gas_price.go
@@ -30,7 +30,7 @@ func (c *ethConnector) GasPriceEstimate(ctx context.Context, _ *ffcapi.GasPriceE
 	// Note we use simple (pre London fork) gas fee approach.
 	// See https://github.com/ethereum/pm/issues/328#issuecomment-853234014 for a bit of color
 	var gasPrice ethtypes.HexInteger
-	rpcErr := c.backend.CallRPC(ctx, &gasPrice, "eth_gasPrice")
+	rpcErr := c.rpc.CallRPC(ctx, &gasPrice, "eth_gasPrice")
 	if rpcErr != nil {
 		return nil, "", rpcErr.Error()
 	}

--- a/internal/ethereum/get_next_nonce.go
+++ b/internal/ethereum/get_next_nonce.go
@@ -27,7 +27,7 @@ import (
 func (c *ethConnector) NextNonceForSigner(ctx context.Context, req *ffcapi.NextNonceForSignerRequest) (*ffcapi.NextNonceForSignerResponse, ffcapi.ErrorReason, error) {
 
 	var txnCount ethtypes.HexInteger
-	rpcErr := c.backend.CallRPC(ctx, &txnCount, "eth_getTransactionCount", req.Signer, "pending")
+	rpcErr := c.rpc.CallRPC(ctx, &txnCount, "eth_getTransactionCount", req.Signer, "pending")
 	if rpcErr != nil {
 		return nil, "", rpcErr.Error()
 	}

--- a/internal/ethereum/get_receipt.go
+++ b/internal/ethereum/get_receipt.go
@@ -73,7 +73,7 @@ func (c *ethConnector) getTransactionInfo(ctx context.Context, hash ethtypes.Hex
 		return cached.(*ethrpc.TxInfoJSONRPC), nil
 	}
 
-	rpcErr := c.backend.CallRPC(ctx, &txInfo, "eth_getTransactionByHash", hash)
+	rpcErr := c.rpc.CallRPC(ctx, &txInfo, "eth_getTransactionByHash", hash)
 	var err error
 	if rpcErr != nil {
 		err = rpcErr.Error()
@@ -108,7 +108,7 @@ func (c *ethConnector) getErrorInfo(ctx context.Context, transactionHash string,
 			log.L(ctx).Trace("No revert reason for the failed transaction found in the receipt. Calling debug_traceTransaction to retrieve it.")
 			// Attempt to get the return value of the transaction - not possible on all RPC endpoints
 			var debugTrace *txDebugTrace
-			traceErr := c.backend.CallRPC(ctx, &debugTrace, "debug_traceTransaction", transactionHash)
+			traceErr := c.rpc.CallRPC(ctx, &debugTrace, "debug_traceTransaction", transactionHash)
 			if traceErr != nil {
 				msg := i18n.NewError(ctx, msgs.MsgUnableToCallDebug, traceErr).Error()
 				return nil, &msg
@@ -171,7 +171,7 @@ func (c *ethConnector) TransactionReceipt(ctx context.Context, req *ffcapi.Trans
 
 	// Get the receipt in the back-end JSON/RPC format
 	var ethReceipt *ethrpc.TxReceiptJSONRPC
-	rpcErr := c.backend.CallRPC(ctx, &ethReceipt, "eth_getTransactionReceipt", req.TransactionHash)
+	rpcErr := c.rpc.CallRPC(ctx, &ethReceipt, "eth_getTransactionReceipt", req.TransactionHash)
 	if rpcErr != nil {
 		return nil, "", rpcErr.Error()
 	}

--- a/internal/ethereum/send_transaction.go
+++ b/internal/ethereum/send_transaction.go
@@ -37,7 +37,7 @@ func (c *ethConnector) TransactionSend(ctx context.Context, req *ffcapi.Transact
 	var rpcError *rpcbackend.RPCError
 	var txHash ethtypes.HexBytes0xPrefix
 	if req.PreSigned {
-		rpcError = c.backend.CallRPC(ctx, &txHash, "eth_sendRawTransaction", req.TransactionData)
+		rpcError = c.rpc.CallRPC(ctx, &txHash, "eth_sendRawTransaction", req.TransactionData)
 	} else {
 		txData, err := hex.DecodeString(strings.TrimPrefix(req.TransactionData, "0x"))
 		if err != nil {
@@ -53,7 +53,7 @@ func (c *ethConnector) TransactionSend(ctx context.Context, req *ffcapi.Transact
 		if err != nil {
 			return nil, ffcapi.ErrorReasonInvalidInputs, err
 		}
-		rpcError = c.backend.CallRPC(ctx, &txHash, "eth_sendTransaction", tx)
+		rpcError = c.rpc.CallRPC(ctx, &txHash, "eth_sendTransaction", tx)
 	}
 
 	if rpcError == nil && len(txHash) != 32 {

--- a/internal/ethereum/statuses.go
+++ b/internal/ethereum/statuses.go
@@ -31,7 +31,7 @@ func (c *ethConnector) IsLive(_ context.Context) (*ffcapi.LiveResponse, ffcapi.E
 }
 
 func (c *ethConnector) IsReady(ctx context.Context) (*ffcapi.ReadyResponse, ffcapi.ErrorReason, error) {
-	err := c.backend.CallRPC(ctx, &c.chainID, "net_version")
+	err := c.rpc.CallRPC(ctx, &c.chainID, "net_version")
 	if err != nil {
 		return &ffcapi.ReadyResponse{
 			Ready: false,

--- a/internal/msgs/en_config_descriptions.go
+++ b/internal/msgs/en_config_descriptions.go
@@ -29,6 +29,7 @@ var ffc = func(key, translation string, fieldType string) i18n.ConfigMessageKey 
 var (
 	_ = ffc("config.connector.url", "URL of JSON/RPC endpoint for the Ethereum node/gateway", "string")
 	_ = ffc("config.connector.ws.enabled", "When true a WebSocket is established for block listening, in addition to the HTTP RPC connections used for other functions", i18n.BooleanType)
+	_ = ffc("config.connector.rpcRoutingMode", "Which connection JSON/RPC calls are made on when a WebSocket is enabled. 'auto' routes node-sticky chain queries (blocks, logs, filters, receipts) to the WebSocket and stateless calls (submission, gas, balance) to the HTTP connection pool. 'ws' routes everything to the WebSocket. 'http' routes everything to the HTTP connection pool, leaving the WebSocket to carry only the newHeads subscription. 'legacy' reproduces the routing used before this setting existed, where only the block listener used the WebSocket", "http,ws,auto,legacy")
 	_ = ffc("config.connector.dataFormat", "Configure the JSON data format for query output and events", "map,flat_array,self_describing")
 	_ = ffc("config.connector.gasEstimationFactor", "The factor to apply to the gas estimation to determine the gas limit", i18n.FloatType)
 	_ = ffc("config.connector.blockCacheSize", "Maximum of blocks to hold in the block info cache", i18n.IntType)

--- a/internal/msgs/en_error_messages.go
+++ b/internal/msgs/en_error_messages.go
@@ -92,4 +92,7 @@ var (
 	MsgMonitoredHeadLengthInvalid               = ffe("FF23072", "Monitored head length must be greater than or equal to 1 value=%d")
 	MsgUnknownJSONFormatOptionValue             = ffe("FF23073", "Unknown value '%s' for JSON formatting option '%s'. Supported values: %s")
 	MsgMetricsInitFail                          = ffe("FF23074", "Failed to initialize metrics for subsystem '%s'")
+	MsgInvalidRPCRoutingMode                    = ffe("FF23075", "Invalid JSON/RPC routing mode '%s': must be 'http', 'ws', 'auto' or 'legacy'")
+	MsgWebSocketNotConfigured                   = ffe("FF23076", "A WebSocket connection is not configured")
+	MsgRPCClientClosed                          = ffe("FF23077", "The JSON/RPC client is closed")
 )

--- a/mocks/ethblocklistenermocks/block_listener.go
+++ b/mocks/ethblocklistenermocks/block_listener.go
@@ -10,7 +10,6 @@ import (
 	ethblocklistener "github.com/hyperledger-firefly/evmconnect/pkg/ethblocklistener"
 	ethrpc "github.com/hyperledger-firefly/evmconnect/pkg/ethrpc"
 	ethtypes "github.com/hyperledger-firefly/signer/pkg/ethtypes"
-	rpcbackend "github.com/hyperledger-firefly/signer/pkg/rpcbackend"
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -27,26 +26,6 @@ func (_m *BlockListener) AddConsumer(ctx context.Context, c *ethblocklistener.Bl
 // FetchBlockReceiptsAsync provides a mock function with given fields: blockNumber, blockHash, cb
 func (_m *BlockListener) FetchBlockReceiptsAsync(blockNumber uint64, blockHash ethtypes.HexBytes0xPrefix, cb func([]*ethrpc.TxReceiptJSONRPC, error)) {
 	_m.Called(blockNumber, blockHash, cb)
-}
-
-// GetBackend provides a mock function with no fields
-func (_m *BlockListener) GetBackend() rpcbackend.RPC {
-	ret := _m.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetBackend")
-	}
-
-	var r0 rpcbackend.RPC
-	if rf, ok := ret.Get(0).(func() rpcbackend.RPC); ok {
-		r0 = rf()
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(rpcbackend.RPC)
-		}
-	}
-
-	return r0
 }
 
 // GetBlockGasLimit provides a mock function with no fields
@@ -405,11 +384,6 @@ func (_m *BlockListener) SnapshotMonitoredHeadChain() []*ethrpc.BlockInfoJSONRPC
 	}
 
 	return r0
-}
-
-// UTSetBackend provides a mock function with given fields: _a0
-func (_m *BlockListener) UTSetBackend(_a0 rpcbackend.RPC) {
-	_m.Called(_a0)
 }
 
 // WaitClosed provides a mock function with no fields

--- a/pkg/ethblocklistener/block_receipt_fetcher.go
+++ b/pkg/ethblocklistener/block_receipt_fetcher.go
@@ -61,7 +61,7 @@ func (brr *blockReceiptRequest) run() {
 		}
 		brr.cb(receipts, err)
 	}()
-	rpc := brr.bl.backend
+	rpc := brr.bl.rpc
 
 	if brr.bl.UseGetBlockReceipts {
 		// just need to make a single call to get all the receipts

--- a/pkg/ethblocklistener/blocklistener.go
+++ b/pkg/ethblocklistener/blocklistener.go
@@ -23,13 +23,11 @@ import (
 	"time"
 
 	lru "github.com/hashicorp/golang-lru"
-	"github.com/hyperledger-firefly/common/pkg/ffresty"
 	"github.com/hyperledger-firefly/common/pkg/fftypes"
 	"github.com/hyperledger-firefly/common/pkg/i18n"
 	"github.com/hyperledger-firefly/common/pkg/log"
 	"github.com/hyperledger-firefly/common/pkg/metric"
 	"github.com/hyperledger-firefly/common/pkg/retry"
-	"github.com/hyperledger-firefly/common/pkg/wsclient"
 	"github.com/hyperledger-firefly/evmconnect/internal/msgs"
 	"github.com/hyperledger-firefly/evmconnect/internal/retryutil"
 	"github.com/hyperledger-firefly/evmconnect/pkg/etherrors"
@@ -88,8 +86,6 @@ type BlockListener interface {
 	FetchBlockReceiptsAsync(blockNumber uint64, blockHash ethtypes.HexBytes0xPrefix, cb func([]*ethrpc.TxReceiptJSONRPC, error))
 	SnapshotMonitoredHeadChain() []*ethrpc.BlockInfoJSONRPC // snapshot the whole view, with complete blocks, using the read-lock.
 	WaitClosed()
-	GetBackend() rpcbackend.RPC
-	UTSetBackend(rpcbackend.RPC)
 	InitMetrics(ctx context.Context, registry metric.MetricsRegistry) error
 }
 
@@ -113,8 +109,7 @@ type BlockUpdateConsumer struct {
 type blockListener struct {
 	ctx            context.Context
 	retry          *retryutil.RetryWrapper
-	backend        rpcbackend.RPC
-	wsBackend      rpcbackend.WebSocketRPCClient // if configured the getting the blockheight will not complete until WS connects, overrides backend once connected
+	rpc            ethrpc.Client // shared with the rest of the connector - routes each call to HTTP or the WebSocket per its configured mode
 	listenLoopDone chan struct{}
 
 	isStarted bool
@@ -150,27 +145,18 @@ type blockListener struct {
 	metrics     metric.MetricsManager
 }
 
-func NewBlockListener(ctx context.Context, retry *retry.Retry, conf *BlockListenerConfig, httpConf *ffresty.Config, wsConf *wsclient.WSConfig) (bl BlockListener, err error) {
-	httpClient := ffresty.NewWithConfig(ctx, *httpConf)
-	var wsBackend rpcbackend.WebSocketRPCClient
-	if wsConf != nil {
-		wsBackend = rpcbackend.NewWSRPCClient(wsConf)
-	}
-	return NewBlockListenerSupplyBackend(ctx, retry, conf, rpcbackend.NewRPCClient(httpClient), wsBackend)
-}
-
-func NewBlockListenerSupplyBackend(ctx context.Context, retry *retry.Retry, conf *BlockListenerConfig, httpBackend rpcbackend.RPC, wsBackend rpcbackend.WebSocketRPCClient) (_ BlockListener, err error) {
+func NewBlockListener(ctx context.Context, retry *retry.Retry, conf *BlockListenerConfig, rpc ethrpc.Client) (_ BlockListener, err error) {
 	if conf.MaxAsyncBlockFetchConcurrency <= 0 {
 		conf.MaxAsyncBlockFetchConcurrency = 1
 	}
 	if conf.ChainTrackingMode == "" {
 		conf.ChainTrackingMode = ffcapi.ChainTrackingModeFull
 	}
+	ctx = log.WithLogFields(ctx, "role", "blocklistener")
 	bl := &blockListener{
-		ctx:                           log.WithLogFields(ctx, "role", "blocklistener"),
+		ctx:                           ctx,
 		retry:                         &retryutil.RetryWrapper{Retry: retry},
-		backend:                       httpBackend, // use the HTTP backend - might get overwritten by a connected websocket later
-		wsBackend:                     wsBackend,
+		rpc:                           rpc,
 		isStarted:                     false,
 		startDone:                     make(chan struct{}),
 		initialBlockHeightObtained:    make(chan struct{}),
@@ -198,14 +184,6 @@ func NewBlockListenerSupplyBackend(ctx context.Context, retry *retry.Retry, conf
 		}
 	}
 	return bl, nil
-}
-
-func (bl *blockListener) GetBackend() rpcbackend.RPC {
-	return bl.backend
-}
-
-func (bl *blockListener) UTSetBackend(backend rpcbackend.RPC) {
-	bl.backend = backend
 }
 
 func (bl *blockListener) GetMonitoredHeadLength() int {
@@ -270,34 +248,23 @@ func (bl *blockListener) newHeadsSubListener() {
 
 // getBlockHeightWithRetry keeps retrying attempting to get the initial block height until successful
 func (bl *blockListener) establishBlockHeightWithRetry() error {
-	wsConnected := false
 	return bl.retry.Do(bl.ctx, "get initial block height", func(_ int) (retry bool, err error) {
-		// If we have a WebSocket backend, then we connect it and switch over to using it
-		// (we accept an un-locked update here to backend, as the most important routine that's
-		// querying block state is the one we're called on)
-		if bl.wsBackend != nil {
-			if !wsConnected {
-				if err := bl.wsBackend.Connect(bl.ctx); err != nil {
-					log.L(bl.ctx).Warnf("WebSocket connection failed, blocking startup of block listener: %s", err)
-					return true, err
-				}
-				bl.backend = bl.wsBackend
-				// if we retry subscribe, we don't want to retry connect
-				wsConnected = true
+		// If a websocket is configured, we block startup until it is connected
+		// Note: The caller is welcome to connect the websocket before creating the block listener.
+		if bl.rpc.HasWebSocket() {
+			if err := bl.rpc.Connect(); err != nil {
+				log.L(bl.ctx).Warnf("WebSocket connection failed, blocking startup of block listener: %s", err)
+				return true, err
 			}
 			if bl.newHeadsSub == nil {
 				// Once subscribed the backend will keep us subscribed over reconnect
-				sub, rpcErr := bl.wsBackend.Subscribe(bl.ctx, "newHeads")
+				sub, rpcErr := bl.rpc.Subscribe(bl.ctx, "newHeads")
 				if rpcErr != nil {
 					return true, rpcErr.Error()
 				}
 				bl.newHeadsSub = sub
 				go bl.newHeadsSubListener()
 			}
-			// Ok all JSON/RPC from this point on uses our WS Backend, thus ensuring we're
-			// sticky to the same node that the WS is connected to when we're doing queries
-			// and building our cache.
-			bl.backend = bl.wsBackend
 		}
 
 		// Now get the block height
@@ -316,7 +283,7 @@ func (bl *blockListener) establishBlockHeightWithRetry() error {
 // state. Caller must not hold canonicalChainLock. The height the node reports is recorded on the target block height gauge.
 func (bl *blockListener) queryBlockHeightFromRPC() (uint64, error) {
 	var hexBlockHeight ethtypes.HexInteger
-	rpcErr := bl.backend.CallRPC(bl.ctx, &hexBlockHeight, "eth_blockNumber")
+	rpcErr := bl.rpc.CallRPC(bl.ctx, &hexBlockHeight, "eth_blockNumber")
 	if rpcErr != nil {
 		bl.incPollFailureMetric("eth_blockNumber")
 		return 0, rpcErr.Error()
@@ -382,7 +349,7 @@ func (bl *blockListener) listenLoop() {
 		}
 
 		if filter == "" {
-			err := bl.backend.CallRPC(bl.ctx, &filter, "eth_newBlockFilter")
+			err := bl.rpc.CallRPC(bl.ctx, &filter, "eth_newBlockFilter")
 			if err != nil {
 				log.L(bl.ctx).Errorf("Failed to establish new block filter: %s", err.Message)
 				bl.incPollFailureMetric("eth_newBlockFilter")
@@ -400,7 +367,7 @@ func (bl *blockListener) listenLoop() {
 			notifyPos = bl.reconcileCanonicalChain(seedBi)
 			seedBi = nil
 		} else {
-			rpcErr := bl.backend.CallRPC(bl.ctx, &blockHashes, "eth_getFilterChanges", filter)
+			rpcErr := bl.rpc.CallRPC(bl.ctx, &blockHashes, "eth_getFilterChanges", filter)
 			if rpcErr != nil {
 				if etherrors.MapError(etherrors.FilterRPCMethods, rpcErr.Error()) == ffcapi.ErrorReasonNotFound {
 					log.L(bl.ctx).Warnf("Block filter '%v' no longer valid. Recreating filter: %s", filter, rpcErr.Message)
@@ -839,10 +806,6 @@ func (bl *blockListener) WaitClosed() {
 	bl.consumerMux.Lock()
 	listenLoopDone := bl.listenLoopDone
 	bl.consumerMux.Unlock()
-	if bl.wsBackend != nil {
-		_ = bl.wsBackend.UnsubscribeAll(bl.ctx)
-		bl.wsBackend.Close()
-	}
 	if listenLoopDone != nil {
 		select {
 		case <-listenLoopDone:

--- a/pkg/ethblocklistener/blocklistener_blockquery.go
+++ b/pkg/ethblocklistener/blocklistener_blockquery.go
@@ -60,7 +60,7 @@ func (bl *blockListener) GetTransactionReceipt(ctx context.Context, txHash strin
 	if receipt, ok := bl.getCachedTransactionReceipt(txHash); ok {
 		return receipt, nil
 	}
-	rpcErr := bl.backend.CallRPC(ctx, &ethReceipt, "eth_getTransactionReceipt", txHash)
+	rpcErr := bl.rpc.CallRPC(ctx, &ethReceipt, "eth_getTransactionReceipt", txHash)
 	if rpcErr != nil || ethReceipt == nil {
 		var err error
 		if rpcErr != nil {
@@ -116,7 +116,7 @@ func (bl *blockListener) GetBlockInfoByHash(ctx context.Context, hash0xString st
 
 // Does not use cache, but will add to cache
 func (bl *blockListener) GetEVMBlockWithTxHashesByHash(ctx context.Context, hash0xString string) (b *ethrpc.EVMBlockWithTxHashesJSONRPC, err error) {
-	rpcErr := bl.backend.CallRPC(ctx, &b, "eth_getBlockByHash", hash0xString, false /* only the txn hashes */)
+	rpcErr := bl.rpc.CallRPC(ctx, &b, "eth_getBlockByHash", hash0xString, false /* only the txn hashes */)
 	if rpcErr != nil {
 		return nil, rpcErr.Error()
 	}
@@ -128,7 +128,7 @@ func (bl *blockListener) GetEVMBlockWithTxHashesByHash(ctx context.Context, hash
 
 // Does not use cache, but will add to cache
 func (bl *blockListener) GetEVMBlockWithTransactionsByHash(ctx context.Context, hash0xString string) (b *ethrpc.EVMBlockWithTransactionsJSONRPC, err error) {
-	rpcErr := bl.backend.CallRPC(ctx, &b, "eth_getBlockByHash", hash0xString, true /* full blocks */)
+	rpcErr := bl.rpc.CallRPC(ctx, &b, "eth_getBlockByHash", hash0xString, true /* full blocks */)
 	if rpcErr != nil {
 		return nil, rpcErr.Error()
 	}
@@ -140,7 +140,7 @@ func (bl *blockListener) GetEVMBlockWithTransactionsByHash(ctx context.Context, 
 
 // Does not use cache, but will add to cache
 func (bl *blockListener) GetEVMBlockWithTxHashesByNumber(ctx context.Context, numberLookup string) (b *ethrpc.EVMBlockWithTxHashesJSONRPC, err error) {
-	rpcErr := bl.backend.CallRPC(ctx, &b, "eth_getBlockByNumber", numberLookup, false /* only the txn hashes */)
+	rpcErr := bl.rpc.CallRPC(ctx, &b, "eth_getBlockByNumber", numberLookup, false /* only the txn hashes */)
 	if rpcErr != nil {
 		return nil, rpcErr.Error()
 	}
@@ -152,7 +152,7 @@ func (bl *blockListener) GetEVMBlockWithTxHashesByNumber(ctx context.Context, nu
 
 // Does not use cache, but will add to cache
 func (bl *blockListener) GetEVMBlockWithTransactionsByNumber(ctx context.Context, numberLookup string) (b *ethrpc.EVMBlockWithTransactionsJSONRPC, err error) {
-	rpcErr := bl.backend.CallRPC(ctx, &b, "eth_getBlockByNumber", numberLookup, true /* full blocks */)
+	rpcErr := bl.rpc.CallRPC(ctx, &b, "eth_getBlockByNumber", numberLookup, true /* full blocks */)
 	if rpcErr != nil {
 		return nil, rpcErr.Error()
 	}

--- a/pkg/ethblocklistener/blocklistener_test.go
+++ b/pkg/ethblocklistener/blocklistener_test.go
@@ -25,7 +25,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hyperledger-firefly/common/pkg/ffresty"
 	"github.com/hyperledger-firefly/common/pkg/fftypes"
 	"github.com/hyperledger-firefly/common/pkg/retry"
 	"github.com/hyperledger-firefly/common/pkg/wsclient"
@@ -45,6 +44,14 @@ const testBlockFilterID2 = "block_filter_2"
 
 const shortDelay = 10 * time.Millisecond
 
+// utRPC wraps a mock backend in an HTTP-only JSON/RPC client, for tests that construct a
+// blockListener directly rather than through newTestBlockListener.
+func utRPC(t *testing.T, mRPC rpcbackend.RPC) ethrpc.Client {
+	rpc, err := ethrpc.NewClientWithBackends(t.Context(), ethrpc.RoutingModeHTTP, mRPC, nil)
+	require.NoError(t, err)
+	return rpc
+}
+
 func newTestBlockListener(t *testing.T, confSetup ...func(conf *BlockListenerConfig, mRPC *rpcbackendmocks.Backend, cancelCtx context.CancelFunc)) (context.Context, *blockListener, *rpcbackendmocks.Backend, func()) {
 	ctx, cancelCtx := context.WithCancel(context.Background())
 
@@ -61,11 +68,13 @@ func newTestBlockListener(t *testing.T, confSetup ...func(conf *BlockListenerCon
 	for _, fn := range confSetup {
 		fn(conf, mRPC, cancelCtx)
 	}
-	ibl, err := NewBlockListenerSupplyBackend(ctx, &retry.Retry{
+	rpc, err := ethrpc.NewClientWithBackends(ctx, ethrpc.RoutingModeAuto, mRPC, nil)
+	require.NoError(t, err)
+	ibl, err := NewBlockListener(ctx, &retry.Retry{
 		InitialDelay: shortDelay,
 		MaximumDelay: 50 * time.Millisecond,
 		Factor:       2.0,
-	}, conf, mRPC, nil)
+	}, conf, rpc)
 	require.NoError(t, err)
 
 	require.Equal(t, conf.MonitoredHeadLength, ibl.GetMonitoredHeadLength())
@@ -227,7 +236,7 @@ func TestBlockListenerConstructorFailMonitoredHeadLength(t *testing.T) {
 	_, err := NewBlockListener(context.Background(), &retry.Retry{}, &BlockListenerConfig{
 		BlockCacheSize:      -1,
 		MonitoredHeadLength: -1,
-	}, &ffresty.Config{}, &wsclient.WSConfig{})
+	}, nil)
 	require.Regexp(t, "FF23072", err)
 }
 
@@ -235,7 +244,7 @@ func TestBlockListenerConstructorFailCacheConfig(t *testing.T) {
 	_, err := NewBlockListener(context.Background(), &retry.Retry{}, &BlockListenerConfig{
 		BlockCacheSize:      -1,
 		MonitoredHeadLength: 1,
-	}, &ffresty.Config{}, &wsclient.WSConfig{})
+	}, nil)
 	require.Regexp(t, "FF23040", err)
 
 	_, err = NewBlockListener(context.Background(), &retry.Retry{}, &BlockListenerConfig{
@@ -243,7 +252,7 @@ func TestBlockListenerConstructorFailCacheConfig(t *testing.T) {
 		MonitoredHeadLength: 1,
 		ReceiptCacheEnabled: true,
 		ReceiptCacheSize:    -1,
-	}, &ffresty.Config{}, &wsclient.WSConfig{})
+	}, nil)
 	require.Regexp(t, "FF23040", err)
 }
 
@@ -415,10 +424,16 @@ func TestBlockListenerWSShoulderTap(t *testing.T) {
 	})
 
 	ctx, bl, _, done := newTestBlockListener(t)
-	bl.wsBackend = rpcbackend.NewWSRPCClient(&wsclient.WSConfig{
+	// Swap in a client with a real WebSocket pointed at the test server. Auto mode, so the
+	// chain queries below are the ones that must arrive over the WebSocket - the HTTP mock
+	// has no expectations set, so a call landing there fails the test.
+	mHTTP := &rpcbackendmocks.Backend{}
+	rpc, err := ethrpc.NewClientWithBackends(ctx, ethrpc.RoutingModeAuto, mHTTP, rpcbackend.NewWSRPCClient(&wsclient.WSConfig{
 		HTTPURL:                url,
 		InitialConnectAttempts: 0,
-	})
+	}))
+	require.NoError(t, err)
+	bl.rpc = rpc
 	svrDone := make(chan struct{})
 
 	pingerDone := make(chan struct{})
@@ -1344,9 +1359,6 @@ func TestBlockListenerWaitNextIterationTap(t *testing.T) {
 
 func TestWaitUntilStartedCancelledCtx(t *testing.T) {
 	_, bl, _, done := newTestBlockListener(t)
-
-	bl.UTSetBackend(nil)
-	require.Nil(t, bl.GetBackend())
 
 	cancelledFgCtx, cancelCtx := context.WithCancel(context.Background())
 	cancelCtx()

--- a/pkg/ethblocklistener/blocklistener_test.go
+++ b/pkg/ethblocklistener/blocklistener_test.go
@@ -25,7 +25,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hyperledger-firefly/common/pkg/ffresty"
 	"github.com/hyperledger-firefly/common/pkg/fftypes"
 	"github.com/hyperledger-firefly/common/pkg/retry"
 	"github.com/hyperledger-firefly/common/pkg/wsclient"
@@ -45,6 +44,14 @@ const testBlockFilterID2 = "block_filter_2"
 
 const shortDelay = 10 * time.Millisecond
 
+// utRPC wraps a mock backend in an HTTP-only JSON/RPC client, for tests that construct a
+// blockListener directly rather than through newTestBlockListener.
+func utRPC(t *testing.T, mRPC rpcbackend.RPC) ethrpc.Client {
+	rpc, err := ethrpc.NewClientWithBackends(t.Context(), ethrpc.RoutingModeHTTP, mRPC, nil)
+	require.NoError(t, err)
+	return rpc
+}
+
 func newTestBlockListener(t *testing.T, confSetup ...func(conf *BlockListenerConfig, mRPC *rpcbackendmocks.Backend, cancelCtx context.CancelFunc)) (context.Context, *blockListener, *rpcbackendmocks.Backend, func()) {
 	ctx, cancelCtx := context.WithCancel(context.Background())
 
@@ -61,11 +68,13 @@ func newTestBlockListener(t *testing.T, confSetup ...func(conf *BlockListenerCon
 	for _, fn := range confSetup {
 		fn(conf, mRPC, cancelCtx)
 	}
-	ibl, err := NewBlockListenerSupplyBackend(ctx, &retry.Retry{
+	rpc, err := ethrpc.NewClientWithBackends(ctx, ethrpc.RoutingModeAuto, mRPC, nil)
+	require.NoError(t, err)
+	ibl, err := NewBlockListener(ctx, &retry.Retry{
 		InitialDelay: shortDelay,
 		MaximumDelay: 50 * time.Millisecond,
 		Factor:       2.0,
-	}, conf, mRPC, nil)
+	}, conf, rpc)
 	require.NoError(t, err)
 
 	require.Equal(t, conf.MonitoredHeadLength, ibl.GetMonitoredHeadLength())
@@ -223,7 +232,7 @@ func TestBlockListenerConstructorFailMonitoredHeadLength(t *testing.T) {
 	_, err := NewBlockListener(context.Background(), &retry.Retry{}, &BlockListenerConfig{
 		BlockCacheSize:      -1,
 		MonitoredHeadLength: -1,
-	}, &ffresty.Config{}, &wsclient.WSConfig{})
+	}, nil)
 	require.Regexp(t, "FF23072", err)
 }
 
@@ -231,7 +240,7 @@ func TestBlockListenerConstructorFailCacheConfig(t *testing.T) {
 	_, err := NewBlockListener(context.Background(), &retry.Retry{}, &BlockListenerConfig{
 		BlockCacheSize:      -1,
 		MonitoredHeadLength: 1,
-	}, &ffresty.Config{}, &wsclient.WSConfig{})
+	}, nil)
 	require.Regexp(t, "FF23040", err)
 
 	_, err = NewBlockListener(context.Background(), &retry.Retry{}, &BlockListenerConfig{
@@ -239,7 +248,7 @@ func TestBlockListenerConstructorFailCacheConfig(t *testing.T) {
 		MonitoredHeadLength: 1,
 		ReceiptCacheEnabled: true,
 		ReceiptCacheSize:    -1,
-	}, &ffresty.Config{}, &wsclient.WSConfig{})
+	}, nil)
 	require.Regexp(t, "FF23040", err)
 }
 
@@ -411,10 +420,16 @@ func TestBlockListenerWSShoulderTap(t *testing.T) {
 	})
 
 	ctx, bl, _, done := newTestBlockListener(t)
-	bl.wsBackend = rpcbackend.NewWSRPCClient(&wsclient.WSConfig{
+	// Swap in a client with a real WebSocket pointed at the test server. Auto mode, so the
+	// chain queries below are the ones that must arrive over the WebSocket - the HTTP mock
+	// has no expectations set, so a call landing there fails the test.
+	mHTTP := &rpcbackendmocks.Backend{}
+	rpc, err := ethrpc.NewClientWithBackends(ctx, ethrpc.RoutingModeAuto, mHTTP, rpcbackend.NewWSRPCClient(&wsclient.WSConfig{
 		HTTPURL:                url,
 		InitialConnectAttempts: 0,
-	})
+	}))
+	require.NoError(t, err)
+	bl.rpc = rpc
 	svrDone := make(chan struct{})
 
 	pingerDone := make(chan struct{})
@@ -1340,9 +1355,6 @@ func TestBlockListenerWaitNextIterationTap(t *testing.T) {
 
 func TestWaitUntilStartedCancelledCtx(t *testing.T) {
 	_, bl, _, done := newTestBlockListener(t)
-
-	bl.UTSetBackend(nil)
-	require.Nil(t, bl.GetBackend())
 
 	cancelledFgCtx, cancelCtx := context.WithCancel(context.Background())
 	cancelCtx()

--- a/pkg/ethblocklistener/confirmation_reconciler_test.go
+++ b/pkg/ethblocklistener/confirmation_reconciler_test.go
@@ -668,7 +668,7 @@ func TestBuildConfirmationQueueUsingInMemoryPartialChain_EmptyCanonicalChain(t *
 	mRPC := &rpcbackendmocks.Backend{}
 	bl := &blockListener{
 		canonicalChain: list.New(), // Empty canonical chain
-		backend:        mRPC,
+		rpc:            utRPC(t, mRPC),
 	}
 	bl.blockCache, _ = lru.New(100)
 
@@ -697,7 +697,7 @@ func TestHandleZeroTargetConfirmationCount_EmptyCanonicalChain(t *testing.T) {
 	mRPC := &rpcbackendmocks.Backend{}
 	bl := &blockListener{
 		canonicalChain: list.New(), // Empty canonical chain
-		backend:        mRPC,
+		rpc:            utRPC(t, mRPC),
 	}
 	bl.blockCache, _ = lru.New(100)
 
@@ -992,7 +992,7 @@ func TestBuildConfirmationList_FailedToFetchBlockInfo(t *testing.T) {
 	mRPC := &rpcbackendmocks.Backend{}
 	bl := &blockListener{
 		canonicalChain: createTestChain(150, 150),
-		backend:        mRPC,
+		rpc:            utRPC(t, mRPC),
 	}
 	bl.blockCache, _ = lru.New(100)
 
@@ -1026,7 +1026,7 @@ func TestBuildConfirmationList_NilBlockInfo(t *testing.T) {
 	mRPC := &rpcbackendmocks.Backend{}
 	bl := &blockListener{
 		canonicalChain: createTestChain(150, 150),
-		backend:        mRPC,
+		rpc:            utRPC(t, mRPC),
 	}
 	bl.blockCache, _ = lru.New(100)
 
@@ -1491,7 +1491,7 @@ func newFakedChainBlockListener(t *testing.T, chain *list.List) (*rpcbackendmock
 	blockCache, _ := lru.New(100)
 	bl := &blockListener{
 		canonicalChain: chain,
-		backend:        mRPC,
+		rpc:            utRPC(t, mRPC),
 		blockCache:     blockCache,
 	}
 	return mRPC, bl

--- a/pkg/ethrpc/client.go
+++ b/pkg/ethrpc/client.go
@@ -1,0 +1,270 @@
+// Copyright © 2026 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ethrpc
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/hyperledger-firefly/common/pkg/ffresty"
+	"github.com/hyperledger-firefly/common/pkg/i18n"
+	"github.com/hyperledger-firefly/common/pkg/log"
+	"github.com/hyperledger-firefly/common/pkg/wsclient"
+	"github.com/hyperledger-firefly/evmconnect/internal/msgs"
+	"github.com/hyperledger-firefly/signer/pkg/rpcbackend"
+)
+
+// RoutingMode determines which of the two connections a given JSON/RPC method is sent on.
+type RoutingMode string
+
+const (
+	// RoutingModeHTTP sends every JSON/RPC call over the HTTP connection pool.
+	RoutingModeHTTP RoutingMode = "http"
+	// RoutingModeWS sends every JSON/RPC call over the WebSocket connection.
+	RoutingModeWS RoutingMode = "ws"
+	// RoutingModeAuto picks the connection per method: node-sticky calls go over the
+	// WebSocket, and stateless calls over the HTTP connection pool.
+	// See httpRoutedMethods for the split.
+	RoutingModeAuto RoutingMode = "auto"
+	// RoutingModeLegacy reproduces the routing that existed before this was configurable.
+	// See wsRoutedMethodsLegacy for exactly what it does, and for the two places
+	// it cannot match the old behavior precisely.
+	RoutingModeLegacy RoutingMode = "legacy"
+)
+
+// httpRoutedMethods are the JSON/RPC methods that carry no node-scoped state, and so are
+// safe (and preferable) to spread across the load-balanced HTTP connection pool when
+// running in RoutingModeAuto.
+//
+// Everything else is node-sticky: block, log, filter and receipt queries must all land on
+// the same node as each other so that filter IDs stay valid, and so that the view of the
+// chain we build up is self-consistent.
+//
+// A method that is not listed here routes to the WebSocket in auto mode. That is the safe
+// default to have: a new chain-query method that silently spread itself across the HTTP
+// pool would break stickiness in a way that only shows up as rare inconsistencies, whereas
+// a new submission method landing on the WebSocket is merely less parallel than it could be.
+var httpRoutedMethods = map[string]bool{
+	"debug_traceTransaction":  true, // due to the size of the payload mainly
+	"eth_call":                true,
+	"eth_estimateGas":         true,
+	"eth_gasPrice":            true,
+	"eth_getBalance":          true,
+	"eth_getTransactionCount": true,
+	"eth_sendRawTransaction":  true,
+	"eth_sendTransaction":     true,
+}
+
+// wsRoutedMethodsLegacy is the RoutingModeLegacy table - everything not listed here goes over
+// HTTP.
+//
+// Before routing became configurable the split was not by method at all, it was by component:
+// the block listener swapped its whole backend over to the WebSocket once connected, and every
+// other part of the connector - including the event streams - held an HTTP-only backend and
+// never touched the WebSocket. This table is that split expressed by method name, which it can
+// be for every method called by only one of the two sides.
+//
+// Two methods are called by both sides, so no method-name table can reproduce the old routing
+// exactly. Where they land here, and why:
+//
+//   - eth_getTransactionReceipt: the block listener fetched receipts over the WebSocket, and
+//     the connector's own TransactionReceipt operation fetched them over HTTP. Listed here, so
+//     the block listener's path (much the higher volume of the two, in full tracking mode) is
+//     preserved and the connector's moves onto the WebSocket.
+//
+//   - eth_getFilterChanges: the block listener polled its block filter over the WebSocket, and
+//     the event streams polled their log filters over HTTP. NOT listed here, so the event
+//     streams are preserved - they are the higher volume, and they are the traffic anyone
+//     reaching for this mode is most likely trying to move back off the WebSocket.
+var wsRoutedMethodsLegacy = map[string]bool{
+	"eth_blockNumber":           true,
+	"eth_getBlockByHash":        true,
+	"eth_getBlockByNumber":      true,
+	"eth_getBlockReceipts":      true,
+	"eth_getTransactionReceipt": true,
+}
+
+// Client is the single JSON/RPC entry point for the connector. It owns both the HTTP
+// connection pool and the WebSocket connection (when one is configured), and decides which
+// of them each call goes on based on the method name and the configured RoutingMode.
+//
+// Call sites do not choose a connection - they just call CallRPC.
+//
+// If Connect() is not called, every call routes to HTTP regardless of mode.
+type Client interface {
+	rpcbackend.RPC
+
+	// Connect establishes the WebSocket connection if one is configured, and is a no-op
+	// otherwise. It is idempotent so can be called multiple times, but fails after Close.
+	Connect() error
+
+	// Subscribe establishes a subscription on the WebSocket connection. It is an error to
+	// call this when no WebSocket is configured - check HasWebSocket first.
+	Subscribe(ctx context.Context, params ...interface{}) (rpcbackend.Subscription, *rpcbackend.RPCError)
+
+	// HasWebSocket returns true if a WebSocket connection is configured. Note this is
+	// independent of the routing mode - a WebSocket can be configured purely to carry
+	// subscriptions, with all JSON/RPC calls going over HTTP.
+	HasWebSocket() bool
+
+	// RoutingMode returns the mode this client was constructed with.
+	RoutingMode() RoutingMode
+
+	// Close unsubscribes and closes the WebSocket connection (currently does not
+	// prevent use of HTTP RPC calls after close)
+	Close()
+}
+
+// Config is the configuration for a Client built from connection configuration.
+type Config struct {
+	RoutingMode           RoutingMode
+	HTTP                  *ffresty.Config
+	WS                    *wsclient.WSConfig // nil when no WebSocket is configured
+	MaxConcurrentRequests int64
+}
+
+type client struct {
+	mode        RoutingMode
+	httpBackend rpcbackend.RPC
+	wsBackend   rpcbackend.WebSocketRPCClient
+	wsCtx       context.Context    // used by the websocket
+	cancelWSCtx context.CancelFunc // allows connect to be cancelled
+	connectMux  sync.Mutex         // serializes Connect against Close, and guards closed
+	closed      bool
+	wsConnected atomic.Bool
+}
+
+// NewClient builds a Client from config
+func NewClient(ctx context.Context, conf *Config) (Client, error) {
+	var wsBackend rpcbackend.WebSocketRPCClient
+	if conf.WS != nil {
+		wsBackend = rpcbackend.NewWSRPCClient(conf.WS)
+	}
+	httpBackend := rpcbackend.NewRPCClientWithOption(ffresty.NewWithConfig(ctx, *conf.HTTP), rpcbackend.RPCClientOptions{
+		MaxConcurrentRequest: conf.MaxConcurrentRequests,
+	})
+	return NewClientWithBackends(ctx, conf.RoutingMode, httpBackend, wsBackend)
+}
+
+// NewClientWithBackends builds a client with existing backends already constructed
+func NewClientWithBackends(ctx context.Context, mode RoutingMode, httpBackend rpcbackend.RPC, wsBackend rpcbackend.WebSocketRPCClient) (Client, error) {
+	if mode == "" {
+		mode = RoutingModeAuto
+	}
+	switch mode {
+	case RoutingModeHTTP, RoutingModeWS, RoutingModeAuto, RoutingModeLegacy:
+	default:
+		return nil, i18n.NewError(ctx, msgs.MsgInvalidRPCRoutingMode, mode)
+	}
+	log.L(ctx).Infof("JSON/RPC routing mode '%s' (websocket configured=%t)", mode, wsBackend != nil)
+	c := &client{
+		mode:        mode,
+		httpBackend: httpBackend,
+		wsBackend:   wsBackend,
+	}
+	c.wsCtx, c.cancelWSCtx = context.WithCancel(ctx)
+	return c, nil
+}
+
+func (c *client) RoutingMode() RoutingMode {
+	return c.mode
+}
+
+func (c *client) HasWebSocket() bool {
+	return c.wsBackend != nil
+}
+
+// routeFor picks the connection for a method. Until the WebSocket is connected, or if there
+// is no WebSocket at all, everything goes to HTTP.
+func (c *client) routeFor(method string) rpcbackend.RPC {
+	if c.wsBackend == nil || !c.wsConnected.Load() {
+		return c.httpBackend
+	}
+	switch c.mode {
+	case RoutingModeWS:
+		return c.wsBackend
+	case RoutingModeAuto:
+		if !httpRoutedMethods[method] {
+			return c.wsBackend
+		}
+	case RoutingModeLegacy:
+		if wsRoutedMethodsLegacy[method] {
+			return c.wsBackend
+		}
+	}
+	// RoutingModeHTTP, plus the methods each of the per-method modes leaves on HTTP
+	return c.httpBackend
+}
+
+func (c *client) CallRPC(ctx context.Context, result interface{}, method string, params ...interface{}) *rpcbackend.RPCError {
+	return c.routeFor(method).CallRPC(ctx, result, method, params...)
+}
+
+func (c *client) Connect() error {
+	if c.wsBackend == nil {
+		log.L(c.wsCtx).Infof("JSON/RPC only has a HTTP connection (routing mode '%s' does not affect behavior)", c.mode)
+		return nil
+	}
+
+	c.connectMux.Lock()
+	defer c.connectMux.Unlock()
+	if c.wsConnected.Load() {
+		return nil
+	}
+	if c.closed || c.wsCtx.Err() != nil {
+		return i18n.NewError(c.wsCtx, msgs.MsgRPCClientClosed)
+	}
+	if err := c.wsBackend.Connect(c.wsCtx); err != nil {
+		return err
+	}
+	// The WS connection is established by the time we get here (regardless of backgroundConnect options).
+	c.wsConnected.Store(true)
+	log.L(c.wsCtx).Infof("JSON/RPC WebSocket connected - routing mode '%s' now fully in effect", c.mode)
+	return nil
+}
+
+func (c *client) Subscribe(ctx context.Context, params ...interface{}) (rpcbackend.Subscription, *rpcbackend.RPCError) {
+	if c.wsBackend == nil {
+		return nil, rpcbackend.NewRPCError(ctx, rpcbackend.RPCCodeInternalError, msgs.MsgWebSocketNotConfigured)
+	}
+	return c.wsBackend.Subscribe(ctx, params...)
+}
+
+func (c *client) Close() {
+	// Release any Connect that is blocked waiting for a socket before taking mutex
+	c.cancelWSCtx()
+
+	c.connectMux.Lock()
+	defer c.connectMux.Unlock()
+	if c.closed {
+		return
+	}
+	// Cleanup the ws
+	if c.wsBackend != nil {
+		// Perform the unsubscribe best-effort on the background thread
+		bgCtx, cancelCtx := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancelCtx()
+		_ = c.wsBackend.UnsubscribeAll(bgCtx)
+		c.wsBackend.Close()
+		c.wsConnected.Store(false)
+		// Now the socket is closed, release the context that was carrying its lifetime
+		c.cancelWSCtx()
+	}
+	c.closed = true
+}

--- a/pkg/ethrpc/client_test.go
+++ b/pkg/ethrpc/client_test.go
@@ -1,0 +1,496 @@
+// Copyright © 2026 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ethrpc
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/hyperledger-firefly/common/pkg/ffresty"
+	"github.com/hyperledger-firefly/common/pkg/wsclient"
+	"github.com/hyperledger-firefly/evmconnect/mocks/rpcbackendmocks"
+	"github.com/hyperledger-firefly/signer/pkg/rpcbackend"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// mockWSBackend is a mock rpcbackend.Backend with the extra WebSocketRPCClient methods, so
+// we can assert which of the two connections a call was routed to.
+type mockWSBackend struct {
+	rpcbackendmocks.Backend
+	connectErr  error
+	connections int
+	// blockConnect makes Connect hang until its context is cancelled, modelling a node that
+	// accepts the TCP connection and then never completes the handshake
+	blockConnect  bool
+	connectCtx    context.Context
+	connectedCtxs chan context.Context
+	sub           rpcbackend.Subscription
+	subErr        *rpcbackend.RPCError
+	unsubs        int
+	closes        int
+}
+
+func (m *mockWSBackend) Connect(ctx context.Context) error {
+	m.connections++
+	m.connectCtx = ctx
+	if m.connectedCtxs != nil {
+		m.connectedCtxs <- ctx
+	}
+	if m.blockConnect {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	return m.connectErr
+}
+
+func (m *mockWSBackend) Subscribe(_ context.Context, _ ...interface{}) (rpcbackend.Subscription, *rpcbackend.RPCError) {
+	return m.sub, m.subErr
+}
+
+func (m *mockWSBackend) Subscriptions() []rpcbackend.Subscription { return nil }
+
+func (m *mockWSBackend) UnsubscribeAll(_ context.Context) *rpcbackend.RPCError {
+	m.unsubs++
+	return nil
+}
+
+func (m *mockWSBackend) Close() { m.closes++ }
+
+// newTestClient builds a connected client, and returns the mock behind each connection.
+func newTestClient(t *testing.T, mode RoutingMode) (Client, *rpcbackendmocks.Backend, *mockWSBackend) {
+	mHTTP := &rpcbackendmocks.Backend{}
+	mWS := &mockWSBackend{}
+	c, err := NewClientWithBackends(context.Background(), mode, mHTTP, mWS)
+	require.NoError(t, err)
+	require.NoError(t, c.Connect())
+	return c, mHTTP, mWS
+}
+
+func TestClientRoutingAuto(t *testing.T) {
+	// The full routing table as it stands, asserted end to end. Anything not in
+	// httpRoutedMethods must be node-sticky and land on the WebSocket.
+	httpMethods := []string{
+		"debug_traceTransaction",
+		"eth_call",
+		"eth_estimateGas",
+		"eth_gasPrice",
+		"eth_getBalance",
+		"eth_getTransactionCount",
+		"eth_sendRawTransaction",
+		"eth_sendTransaction",
+	}
+	wsMethods := []string{
+		"eth_blockNumber",
+		"eth_getBlockByHash",
+		"eth_getBlockByNumber",
+		"eth_getBlockReceipts",
+		"eth_getFilterChanges",
+		"eth_getFilterLogs",
+		"eth_getLogs",
+		"eth_getTransactionByHash",
+		"eth_getTransactionReceipt",
+		"eth_newBlockFilter",
+		"eth_newFilter",
+		"eth_uninstallFilter",
+		"net_version",
+		"some_methodWeHaveNeverHeardOf", // unlisted methods are sticky by default
+	}
+
+	assertRouting(t, RoutingModeAuto, httpMethods, wsMethods)
+}
+
+func TestClientRoutingLegacy(t *testing.T) {
+	// Only the block listener used the WebSocket before this was configurable, so its methods
+	// are the WebSocket set and everything else - the whole of the rest of the connector,
+	// event streams included - stays on HTTP.
+	wsMethods := []string{
+		"eth_blockNumber",
+		"eth_getBlockByHash",
+		"eth_getBlockByNumber",
+		"eth_getBlockReceipts",
+		// Called by both sides. The block listener's use is preserved here, so the
+		// connector's own TransactionReceipt operation moves onto the WebSocket.
+		"eth_getTransactionReceipt",
+	}
+	httpMethods := []string{
+		"debug_traceTransaction",
+		"eth_call",
+		"eth_estimateGas",
+		"eth_gasPrice",
+		"eth_getBalance",
+		"eth_getLogs",
+		"eth_getTransactionByHash",
+		"eth_getTransactionCount",
+		"eth_sendRawTransaction",
+		"eth_sendTransaction",
+		"net_version",
+		// The event streams' filter lifecycle, all of which was on HTTP before. The block
+		// listener's block filter is dragged onto HTTP with it - eth_getFilterChanges cannot
+		// be in both sets, and eth_newBlockFilter has to follow it so that the filter is
+		// created and polled on one connection.
+		"eth_getFilterChanges",
+		"eth_getFilterLogs",
+		"eth_newBlockFilter",
+		"eth_newFilter",
+		"eth_uninstallFilter",
+		// Unlisted methods stay on HTTP in this mode, which is where anything the old code
+		// did not explicitly hand to the block listener would have gone
+		"some_methodWeHaveNeverHeardOf",
+	}
+
+	assertRouting(t, RoutingModeLegacy, httpMethods, wsMethods)
+}
+
+// assertRouting drives every method through a connected client, and fails if any of them lands
+// on the connection it was not expected on.
+func assertRouting(t *testing.T, mode RoutingMode, httpMethods, wsMethods []string) {
+	c, mHTTP, mWS := newTestClient(t, mode)
+	for _, method := range httpMethods {
+		mHTTP.On("CallRPC", mock.Anything, mock.Anything, method).Return(nil).Once()
+	}
+	for _, method := range wsMethods {
+		mWS.On("CallRPC", mock.Anything, mock.Anything, method).Return(nil).Once()
+	}
+
+	for _, method := range append(append([]string{}, httpMethods...), wsMethods...) {
+		require.Nil(t, c.CallRPC(context.Background(), nil, method), method)
+	}
+
+	// Each mock asserts it saw exactly the calls expected of it, and no others
+	mHTTP.AssertExpectations(t)
+	mWS.AssertExpectations(t)
+}
+
+func TestClientRoutingAllHTTP(t *testing.T) {
+	c, mHTTP, mWS := newTestClient(t, RoutingModeHTTP)
+	// Including the node-sticky ones - in this mode the WebSocket carries subscriptions only
+	mHTTP.On("CallRPC", mock.Anything, mock.Anything, "eth_getLogs").Return(nil).Once()
+	mHTTP.On("CallRPC", mock.Anything, mock.Anything, "eth_sendTransaction").Return(nil).Once()
+
+	require.Nil(t, c.CallRPC(context.Background(), nil, "eth_getLogs"))
+	require.Nil(t, c.CallRPC(context.Background(), nil, "eth_sendTransaction"))
+
+	mHTTP.AssertExpectations(t)
+	mWS.AssertExpectations(t)
+}
+
+func TestClientRoutingAllWS(t *testing.T) {
+	c, mHTTP, mWS := newTestClient(t, RoutingModeWS)
+	// Including the stateless ones, which give up the HTTP pool's concurrency in this mode
+	mWS.On("CallRPC", mock.Anything, mock.Anything, "eth_getLogs").Return(nil).Once()
+	mWS.On("CallRPC", mock.Anything, mock.Anything, "eth_sendTransaction").Return(nil).Once()
+
+	require.Nil(t, c.CallRPC(context.Background(), nil, "eth_getLogs"))
+	require.Nil(t, c.CallRPC(context.Background(), nil, "eth_sendTransaction"))
+
+	mHTTP.AssertExpectations(t)
+	mWS.AssertExpectations(t)
+}
+
+func TestClientRoutesToHTTPUntilConnected(t *testing.T) {
+	mHTTP := &rpcbackendmocks.Backend{}
+	mWS := &mockWSBackend{}
+	c, err := NewClientWithBackends(context.Background(), RoutingModeWS, mHTTP, mWS)
+	require.NoError(t, err)
+
+	// Even in all-WS mode, a call before Connect degrades to HTTP rather than failing
+	mHTTP.On("CallRPC", mock.Anything, mock.Anything, "eth_blockNumber").Return(nil).Once()
+	require.Nil(t, c.CallRPC(context.Background(), nil, "eth_blockNumber"))
+
+	require.NoError(t, c.Connect())
+
+	mWS.On("CallRPC", mock.Anything, mock.Anything, "eth_blockNumber").Return(nil).Once()
+	require.Nil(t, c.CallRPC(context.Background(), nil, "eth_blockNumber"))
+
+	mHTTP.AssertExpectations(t)
+	mWS.AssertExpectations(t)
+}
+
+func TestClientRoutesToHTTPWithNoWebSocket(t *testing.T) {
+	mHTTP := &rpcbackendmocks.Backend{}
+	c, err := NewClientWithBackends(context.Background(), RoutingModeWS, mHTTP, nil)
+	require.NoError(t, err)
+	assert.False(t, c.HasWebSocket())
+
+	// Connect is a no-op, and everything routes to HTTP whatever the mode asked for
+	require.NoError(t, c.Connect())
+	mHTTP.On("CallRPC", mock.Anything, mock.Anything, "eth_getLogs").Return(nil).Once()
+	require.Nil(t, c.CallRPC(context.Background(), nil, "eth_getLogs"))
+
+	// ... and Close has nothing to do
+	c.Close()
+	mHTTP.AssertExpectations(t)
+}
+
+func TestClientPropagatesResultAndError(t *testing.T) {
+	c, mHTTP, mWS := newTestClient(t, RoutingModeAuto)
+	mHTTP.On("CallRPC", mock.Anything, mock.Anything, "eth_gasPrice").Return(nil).Run(func(args mock.Arguments) {
+		*(args[1].(*string)) = "0x12345"
+	}).Once()
+	mWS.On("CallRPC", mock.Anything, mock.Anything, "eth_getLogs", mock.Anything).
+		Return(&rpcbackend.RPCError{Message: "pop"}).Once()
+
+	var gasPrice string
+	require.Nil(t, c.CallRPC(context.Background(), &gasPrice, "eth_gasPrice"))
+	assert.Equal(t, "0x12345", gasPrice)
+
+	rpcErr := c.CallRPC(context.Background(), nil, "eth_getLogs", "params")
+	require.NotNil(t, rpcErr)
+	assert.Equal(t, "pop", rpcErr.Message)
+
+	mHTTP.AssertExpectations(t)
+	mWS.AssertExpectations(t)
+}
+
+func TestClientConnectIdempotentAndPropagatesFailure(t *testing.T) {
+	mWS := &mockWSBackend{connectErr: fmt.Errorf("pop")}
+	c, err := NewClientWithBackends(context.Background(), RoutingModeAuto, &rpcbackendmocks.Backend{}, mWS)
+	require.NoError(t, err)
+
+	require.Regexp(t, "pop", c.Connect())
+	assert.Equal(t, 1, mWS.connections)
+
+	// A retry after a failed connect does reconnect...
+	mWS.connectErr = nil
+	require.NoError(t, c.Connect())
+	assert.Equal(t, 2, mWS.connections)
+
+	// ... but once connected, a repeat call is a no-op. The block listener calls Connect from
+	// its retry loop, and must not tear down a working connection when only Subscribe failed.
+	require.NoError(t, c.Connect())
+	assert.Equal(t, 2, mWS.connections)
+}
+
+func TestClientSubscribe(t *testing.T) {
+	mSub := &rpcbackendmocks.Subscription{}
+	c, _, mWS := newTestClient(t, RoutingModeAuto)
+	mWS.sub = mSub
+
+	sub, rpcErr := c.Subscribe(context.Background(), "newHeads")
+	require.Nil(t, rpcErr)
+	assert.Same(t, mSub, sub)
+}
+
+func TestClientSubscribeNoWebSocket(t *testing.T) {
+	c, err := NewClientWithBackends(context.Background(), RoutingModeHTTP, &rpcbackendmocks.Backend{}, nil)
+	require.NoError(t, err)
+
+	_, rpcErr := c.Subscribe(context.Background(), "newHeads")
+	require.NotNil(t, rpcErr)
+	assert.Regexp(t, "FF23076", rpcErr.Message)
+}
+
+func TestClientCloseUnsubscribes(t *testing.T) {
+	c, mHTTP, mWS := newTestClient(t, RoutingModeAuto)
+	c.Close()
+	assert.Equal(t, 1, mWS.unsubs)
+	assert.Equal(t, 1, mWS.closes)
+
+	// Close is idempotent - a second call does not unsubscribe or close again
+	c.Close()
+	assert.Equal(t, 1, mWS.unsubs)
+	assert.Equal(t, 1, mWS.closes)
+
+	// Once closed we route at HTTP, rather than at a dead socket
+	mHTTP.On("CallRPC", mock.Anything, mock.Anything, "eth_getLogs").Return(nil).Once()
+	require.Nil(t, c.CallRPC(context.Background(), nil, "eth_getLogs"))
+	mHTTP.AssertExpectations(t)
+
+	// Close is terminal - a Connect racing the shutdown must not establish a socket that
+	// nothing is left to close
+	err := c.Connect()
+	assert.Regexp(t, "FF23077", err)
+	assert.Equal(t, 1, mWS.connections)
+}
+
+func TestClientCloseUnblocksStuckConnect(t *testing.T) {
+	mWS := &mockWSBackend{blockConnect: true, connectedCtxs: make(chan context.Context, 1)}
+	c, err := NewClientWithBackends(context.Background(), RoutingModeAuto, &rpcbackendmocks.Backend{}, mWS)
+	require.NoError(t, err)
+
+	connectDone := make(chan error, 1)
+	go func() {
+		// Note the caller's context is never cancelled here - only Close can release this
+		connectDone <- c.Connect()
+	}()
+	<-mWS.connectedCtxs // wait until we are actually inside the connect, holding the mutex
+
+	c.Close()
+
+	select {
+	case err := <-connectDone:
+		require.Error(t, err) // released with the context cancelled error, not a connection
+	case <-time.After(5 * time.Second):
+		require.Fail(t, "Connect was not released by Close")
+	}
+	assert.False(t, c.(*client).wsConnected.Load())
+	assert.Equal(t, 1, mWS.closes)
+}
+
+func TestClientConnectSurvivesReturn(t *testing.T) {
+	mWS := &mockWSBackend{}
+	c, err := NewClientWithBackends(context.Background(), RoutingModeAuto, &rpcbackendmocks.Backend{}, mWS)
+	require.NoError(t, err)
+	require.NoError(t, c.Connect())
+
+	require.NotNil(t, mWS.connectCtx)
+	require.NoError(t, mWS.connectCtx.Err(), "the connection context was cancelled, which closes the socket")
+
+	// ... and the routing is live over the WebSocket, not degraded back to HTTP
+	mWS.On("CallRPC", mock.Anything, mock.Anything, "eth_getLogs").Return(nil).Once()
+	require.Nil(t, c.CallRPC(context.Background(), nil, "eth_getLogs"))
+	mWS.AssertExpectations(t)
+
+	// Close releases the context that was carrying the socket's lifetime
+	c.Close()
+	assert.Error(t, mWS.connectCtx.Err())
+}
+
+func TestClientConnectCancelledByConstructionContext(t *testing.T) {
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	mWS := &mockWSBackend{}
+	c, err := NewClientWithBackends(ctx, RoutingModeAuto, &rpcbackendmocks.Backend{}, mWS)
+	require.NoError(t, err)
+	require.NoError(t, c.Connect())
+
+	require.NoError(t, mWS.connectCtx.Err())
+	cancelCtx()
+	assert.Error(t, mWS.connectCtx.Err())
+}
+
+func TestClientConnectAfterContextCancelled(t *testing.T) {
+	ctx, cancelCtx := context.WithCancel(context.Background())
+	mWS := &mockWSBackend{}
+	c, err := NewClientWithBackends(ctx, RoutingModeAuto, &rpcbackendmocks.Backend{}, mWS)
+	require.NoError(t, err)
+	cancelCtx()
+
+	assert.Regexp(t, "FF23077", c.Connect())
+	assert.Equal(t, 0, mWS.connections)
+}
+
+func TestClientBadRoutingMode(t *testing.T) {
+	_, err := NewClientWithBackends(context.Background(), RoutingMode("wrong"), &rpcbackendmocks.Backend{}, nil)
+	assert.Regexp(t, "FF23075.*wrong", err)
+}
+
+func TestClientDefaultRoutingMode(t *testing.T) {
+	c, err := NewClientWithBackends(context.Background(), "", &rpcbackendmocks.Backend{}, nil)
+	require.NoError(t, err)
+	assert.Equal(t, RoutingModeAuto, c.RoutingMode())
+}
+
+func TestNewClientFromConfig(t *testing.T) {
+	c, err := NewClient(context.Background(), &Config{
+		RoutingMode:           RoutingModeAuto,
+		HTTP:                  &ffresty.Config{URL: "http://localhost:8545"},
+		WS:                    &wsclient.WSConfig{HTTPURL: "http://localhost:8546"},
+		MaxConcurrentRequests: 10,
+	})
+	require.NoError(t, err)
+	assert.True(t, c.HasWebSocket())
+
+	c, err = NewClient(context.Background(), &Config{
+		HTTP: &ffresty.Config{URL: "http://localhost:8545"},
+	})
+	require.NoError(t, err)
+	assert.False(t, c.HasWebSocket())
+}
+
+func TestClientConcurrentConnect(t *testing.T) {
+	mHTTP := &rpcbackendmocks.Backend{}
+	mHTTP.On("CallRPC", mock.Anything, mock.Anything, "eth_blockNumber").Return(nil).Maybe()
+	mWS := &mockWSBackend{}
+	mWS.On("CallRPC", mock.Anything, mock.Anything, "eth_blockNumber").Return(nil).Maybe()
+
+	c, err := NewClientWithBackends(context.Background(), RoutingModeAuto, mHTTP, mWS)
+	require.NoError(t, err)
+
+	const callers = 20
+	const callsEach = 50
+	var wg sync.WaitGroup
+	wg.Add(callers + 1)
+
+	for i := 0; i < callers; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < callsEach; j++ {
+				require.Nil(t, c.CallRPC(context.Background(), nil, "eth_blockNumber"))
+			}
+		}()
+	}
+	go func() {
+		defer wg.Done()
+		for j := 0; j < callsEach; j++ {
+			require.NoError(t, c.Connect())
+		}
+	}()
+
+	wg.Wait()
+	assert.Equal(t, 1, mWS.connections)
+}
+
+func TestClientConcurrentConnectAndClose(t *testing.T) {
+	mHTTP := &rpcbackendmocks.Backend{}
+	mHTTP.On("CallRPC", mock.Anything, mock.Anything, "eth_blockNumber").Return(nil).Maybe()
+	mWS := &mockWSBackend{}
+	mWS.On("CallRPC", mock.Anything, mock.Anything, "eth_blockNumber").Return(nil).Maybe()
+
+	c, err := NewClientWithBackends(context.Background(), RoutingModeAuto, mHTTP, mWS)
+	require.NoError(t, err)
+
+	const callers = 10
+	const callsEach = 50
+	var wg sync.WaitGroup
+	wg.Add(callers + 2)
+
+	for i := 0; i < callers; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < callsEach; j++ {
+				// Whichever side of the close this lands, it must reach a live connection
+				require.Nil(t, c.CallRPC(context.Background(), nil, "eth_blockNumber"))
+			}
+		}()
+	}
+	go func() {
+		defer wg.Done()
+		for j := 0; j < callsEach; j++ {
+			// Either it connects, or it loses to Close and gets told the client is closed -
+			// never a socket established after Close that nothing will close
+			if err := c.Connect(); err != nil {
+				assert.Regexp(t, "FF23077", err)
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for j := 0; j < callsEach; j++ {
+			c.Close()
+		}
+	}()
+
+	wg.Wait()
+	assert.Equal(t, 1, mWS.closes)
+	assert.Equal(t, 1, mWS.unsubs)
+	assert.LessOrEqual(t, mWS.connections, 1)
+}


### PR DESCRIPTION
EVMConnect has both a HTTP and a WebSocket configuration.

When a WebSocket configuration exists, the block listener connects the WebSocket and then begins to use it.

However, the rest of the listener code continues to use the HTTP connection - meaning we end up with a split where detection of blocks is pinned to a sticky connection over a WebSocket, but the remaining calls happen over HTTP relying on sticky-session HTTP load balancing for calls that require server-side context like `eth_newFilter` / `eth_getFilterChanges`.

This PR introduces a common RPC layer that all aspects of the connector use, which then perform RPC method based selection of whether to send requests down a WebSocket or HTTP connection.

A mix still has benefits:

- High volume submission can utilize concurrent HTTP connections such as `eth_sendRawTransaction`
- Calling read operations like `eth_call` can use multiple backend nodes
- Expensive calls like `debug_traceTransaction` can be moved off of the WebSocket

However, the mix previously used was not ideal.

So the approach here is to have a mode switch that supports:

1. `ws` everything is pushed down the WebSocket once estsablished
2. `http` everything is pushed down HTTP - only use of WebSocket is subscriptions (shoulder taps for new blocks)
3. `auto` a new split that is documented in detail in this PR - the *new default*
4. `legacy` as close as possible to the existing split, with two differences documented in the code