### PR TITLE
Surface block timestamp in confirmationUpdateResult

### DIFF
--- a/pkg/ethblocklistener/blocklistener.go
+++ b/pkg/ethblocklistener/blocklistener.go
@@ -50,13 +50,13 @@ import (
 //
 //	`rebuilt` will be true if an invalid confirmation list is detected by the reconciliation process
 type ConfirmationUpdateResult struct {
-	Confirmations            []*ethrpc.MinimalBlockInfo `json:"confirmations,omitempty"`  // the confirmation list
-	Rebuilt                  bool                       `json:"rebuilt,omitempty"`        // when true, it means the existing confirmations contained invalid blocks, the new confirmations are rebuilt from scratch
-	NewFork                  bool                       `json:"newFork,omitempty"`        // when true, it means a new fork was detected based on the existing confirmations
-	Confirmed                bool                       `json:"confirmed,omitempty"`      // when true, it means the confirmation list is complete and the transaction is confirmed
-	TargetConfirmationCount  uint64                     `json:"targetConfirmationCount"`  // the target number of confirmations for this reconcile request
-	CurrentConfirmationCount uint64                     `json:"currentConfirmationCount"` // the current number of confirmations for this reconcile request
-	Timestamp                *ethtypes.HexUint64        `json:"timestamp,omitempty"`      // the on-chain timestamp of the transaction's block - only populated in "full" chain tracking mode, since "light" mode never fetches a block
+	Confirmations            []*ethrpc.MinimalBlockInfo `json:"confirmations,omitempty"`     // the confirmation list
+	Rebuilt                  bool                       `json:"rebuilt,omitempty"`           // when true, it means the existing confirmations contained invalid blocks, the new confirmations are rebuilt from scratch
+	NewFork                  bool                       `json:"newFork,omitempty"`           // when true, it means a new fork was detected based on the existing confirmations
+	Confirmed                bool                       `json:"confirmed,omitempty"`         // when true, it means the confirmation list is complete and the transaction is confirmed
+	TargetConfirmationCount  uint64                     `json:"targetConfirmationCount"`     // the target number of confirmations for this reconcile request
+	CurrentConfirmationCount uint64                     `json:"currentConfirmationCount"`    // the current number of confirmations for this reconcile request
+	TxnBlockTimestamp        *ethtypes.HexUint64        `json:"txnBlockTimestamp,omitempty"` // the on-chain timestamp of the block the transaction was included in - not a confirmation-finality guarantee, this can change if the chain forks before Confirmed becomes true. Only populated in "full" chain tracking mode, since "light" mode never fetches a block
 }
 
 type BlockListenerConfig struct {

--- a/pkg/ethblocklistener/blocklistener.go
+++ b/pkg/ethblocklistener/blocklistener.go
@@ -56,6 +56,7 @@ type ConfirmationUpdateResult struct {
 	Confirmed                bool                       `json:"confirmed,omitempty"`      // when true, it means the confirmation list is complete and the transaction is confirmed
 	TargetConfirmationCount  uint64                     `json:"targetConfirmationCount"`  // the target number of confirmations for this reconcile request
 	CurrentConfirmationCount uint64                     `json:"currentConfirmationCount"` // the current number of confirmations for this reconcile request
+	Timestamp                *ethtypes.HexUint64        `json:"timestamp,omitempty"`      // the on-chain timestamp of the transaction's block - only populated in "full" chain tracking mode, since "light" mode never fetches a block
 }
 
 type BlockListenerConfig struct {

--- a/pkg/ethblocklistener/confirmation_reconciler.go
+++ b/pkg/ethblocklistener/confirmation_reconciler.go
@@ -64,6 +64,7 @@ func (bl *blockListener) ReconcileConfirmationsForTransaction(ctx context.Contex
 			// no support on fork detection in this mode from the connector although firefly transaction manager will inject `NewFork: true` if it detects a reduction in confirmationCount.
 			CurrentConfirmationCount: currentConfirmationCount,
 			TargetConfirmationCount:  targetConfirmationCount,
+			// Timestamp is intentionally left unset in light mode - the block is never fetched here, only the receipt.
 		}, txReceipt, nil
 	}
 
@@ -84,6 +85,7 @@ func (bl *blockListener) ReconcileConfirmationsForTransaction(ctx context.Contex
 	if confirmationUpdateResult != nil {
 		confirmationUpdateResult.TargetConfirmationCount = targetConfirmationCount
 		confirmationUpdateResult.CurrentConfirmationCount = uint64(len(confirmationUpdateResult.Confirmations)) - 1
+		confirmationUpdateResult.Timestamp = &txBlockInfo.Timestamp
 		// NOTE: This function does not do the full receipt decoding, for which there is a complex function for.
 		// The "Receipt" object is left empty (but the JSON/RPC receipt is return to the caller for enrichment)
 	}

--- a/pkg/ethblocklistener/confirmation_reconciler.go
+++ b/pkg/ethblocklistener/confirmation_reconciler.go
@@ -64,7 +64,7 @@ func (bl *blockListener) ReconcileConfirmationsForTransaction(ctx context.Contex
 			// no support on fork detection in this mode from the connector although firefly transaction manager will inject `NewFork: true` if it detects a reduction in confirmationCount.
 			CurrentConfirmationCount: currentConfirmationCount,
 			TargetConfirmationCount:  targetConfirmationCount,
-			// Timestamp is intentionally left unset in light mode - the block is never fetched here, only the receipt.
+			// TxnBlockTimestamp is intentionally left unset in light mode - the block is never fetched here, only the receipt.
 		}, txReceipt, nil
 	}
 
@@ -85,7 +85,7 @@ func (bl *blockListener) ReconcileConfirmationsForTransaction(ctx context.Contex
 	if confirmationUpdateResult != nil {
 		confirmationUpdateResult.TargetConfirmationCount = targetConfirmationCount
 		confirmationUpdateResult.CurrentConfirmationCount = uint64(len(confirmationUpdateResult.Confirmations)) - 1
-		confirmationUpdateResult.Timestamp = &txBlockInfo.Timestamp
+		confirmationUpdateResult.TxnBlockTimestamp = &txBlockInfo.Timestamp
 		// NOTE: This function does not do the full receipt decoding, for which there is a complex function for.
 		// The "Receipt" object is left empty (but the JSON/RPC receipt is return to the caller for enrichment)
 	}

--- a/pkg/ethblocklistener/confirmation_reconciler_test.go
+++ b/pkg/ethblocklistener/confirmation_reconciler_test.go
@@ -155,7 +155,7 @@ func TestReconcileConfirmationsForTransaction_HeadBlockNumber_FullyConfirmed(t *
 		assert.Equal(t, uint64(5), result.CurrentConfirmationCount)
 		assert.Equal(t, uint64(5), result.TargetConfirmationCount)
 		// Light mode never fetches a block, only the receipt - so no timestamp is ever available here.
-		assert.Nil(t, result.Timestamp)
+		assert.Nil(t, result.TxnBlockTimestamp)
 	}
 }
 
@@ -347,8 +347,8 @@ func TestReconcileConfirmationsForTransaction_NewConfirmation(t *testing.T) {
 		{Number: 1978, Hash: generateTestHash(1978), ParentHash: generateTestHash(1977)},
 	}), result.Confirmations)
 	assert.Equal(t, uint64(5), result.TargetConfirmationCount)
-	if assert.NotNil(t, result.Timestamp) {
-		assert.Equal(t, ethtypes.HexUint64(1735689600), *result.Timestamp)
+	if assert.NotNil(t, result.TxnBlockTimestamp) {
+		assert.Equal(t, ethtypes.HexUint64(1735689600), *result.TxnBlockTimestamp)
 	}
 	assert.NotNil(t, receipt)
 

--- a/pkg/ethblocklistener/confirmation_reconciler_test.go
+++ b/pkg/ethblocklistener/confirmation_reconciler_test.go
@@ -154,6 +154,8 @@ func TestReconcileConfirmationsForTransaction_HeadBlockNumber_FullyConfirmed(t *
 		assert.True(t, result.Confirmed)
 		assert.Equal(t, uint64(5), result.CurrentConfirmationCount)
 		assert.Equal(t, uint64(5), result.TargetConfirmationCount)
+		// Light mode never fetches a block, only the receipt - so no timestamp is ever available here.
+		assert.Nil(t, result.Timestamp)
 	}
 }
 
@@ -328,6 +330,7 @@ func TestReconcileConfirmationsForTransaction_NewConfirmation(t *testing.T) {
 			Number:     1977,
 			Hash:       generateTestHash(1977),
 			ParentHash: generateTestHash(1976),
+			Timestamp:  1735689600, // 2025-01-01T00:00:00Z
 		}}
 	})
 
@@ -344,6 +347,9 @@ func TestReconcileConfirmationsForTransaction_NewConfirmation(t *testing.T) {
 		{Number: 1978, Hash: generateTestHash(1978), ParentHash: generateTestHash(1977)},
 	}), result.Confirmations)
 	assert.Equal(t, uint64(5), result.TargetConfirmationCount)
+	if assert.NotNil(t, result.Timestamp) {
+		assert.Equal(t, ethtypes.HexUint64(1735689600), *result.Timestamp)
+	}
 	assert.NotNil(t, receipt)
 
 	mRPC.AssertExpectations(t)


### PR DESCRIPTION
Surface the block timestamp in the ConfirmationUpdateResult. Scope to full mode only since we do not get the block info in light mode.  