### PR TITLE
Skip chain-catchup checks for zero-confirmation reconciliation

### DIFF
--- a/pkg/ethblocklistener/confirmation_reconciler.go
+++ b/pkg/ethblocklistener/confirmation_reconciler.go
@@ -49,6 +49,13 @@ func (bl *blockListener) ReconcileConfirmationsForTransaction(ctx context.Contex
 			log.L(ctx).Errorf("Failed to fetch transaction receipt using tx hash %s: %v", txHash, err)
 			return nil, nil, err
 		}
+		if targetConfirmationCount == 0 {
+			return &ConfirmationUpdateResult{
+				Confirmed:                true,
+				TargetConfirmationCount:  0,
+				CurrentConfirmationCount: 0,
+			}, txReceipt, nil
+		}
 		// compare it against the chain head
 		chainHead := bl.GetHeadBlockNumber(ctx)
 		if chainHead < txReceipt.BlockNumber.Uint64() {
@@ -365,14 +372,8 @@ func (bl *blockListener) buildConfirmationQueueUsingInMemoryPartialChain(ctx con
 func (bl *blockListener) handleZeroTargetConfirmationCount(ctx context.Context, txBlockInfo *ethrpc.BlockInfoJSONRPC) (*ConfirmationUpdateResult, error) {
 	bl.canonicalChainLock.RLock()
 	defer bl.canonicalChainLock.RUnlock()
-	// if the target confirmation count is 0, and the transaction blocks is before the last block in the in-memory partial chain,
+	// when target confirmation count is set to 0 as it requires no extra blocks from the in-memory partial chain
 	// we can immediately return a confirmed result
-	txBlockNumber := txBlockInfo.Number.Uint64()
-	err := bl.validateChainCaughtUp(ctx, txBlockInfo, txBlockNumber)
-	if err != nil {
-		return nil, err
-	}
-
 	return &ConfirmationUpdateResult{
 		Confirmed:     true,
 		Confirmations: []*ethrpc.MinimalBlockInfo{txBlockInfo.ToMinimalBlockInfo()},

--- a/pkg/ethblocklistener/confirmation_reconciler.go
+++ b/pkg/ethblocklistener/confirmation_reconciler.go
@@ -369,7 +369,7 @@ func (bl *blockListener) buildConfirmationQueueUsingInMemoryPartialChain(ctx con
 	return newConfirmationsWithoutTxBlock, nil
 }
 
-func (bl *blockListener) handleZeroTargetConfirmationCount(ctx context.Context, txBlockInfo *ethrpc.BlockInfoJSONRPC) (*ConfirmationUpdateResult, error) {
+func (bl *blockListener) handleZeroTargetConfirmationCount(_ context.Context, txBlockInfo *ethrpc.BlockInfoJSONRPC) (*ConfirmationUpdateResult, error) {
 	bl.canonicalChainLock.RLock()
 	defer bl.canonicalChainLock.RUnlock()
 	// when target confirmation count is set to 0 as it requires no extra blocks from the in-memory partial chain

--- a/pkg/ethblocklistener/confirmation_reconciler.go
+++ b/pkg/ethblocklistener/confirmation_reconciler.go
@@ -41,6 +41,21 @@ func toBlockInfoList(ffcapiBlocks []*ethrpc.MinimalBlockInfo) (blocks []*ethrpc.
 
 func (bl *blockListener) ReconcileConfirmationsForTransaction(ctx context.Context, txHash string, existingConfirmations []*ethrpc.MinimalBlockInfo, targetConfirmationCount uint64) (*ConfirmationUpdateResult, *ethrpc.TxReceiptJSONRPC, error) {
 
+	if targetConfirmationCount == 0 {
+		// regardless of the chain tracking mode, when target confirmation count is set to 0
+		// we can immediately return a confirmed result without fetching any block information
+		txReceipt, err := bl.GetTransactionReceipt(ctx, txHash)
+		if err != nil {
+			log.L(ctx).Errorf("Failed to fetch transaction receipt using tx hash %s: %v", txHash, err)
+			return nil, nil, err
+		}
+		return &ConfirmationUpdateResult{
+			Confirmed:                true,
+			TargetConfirmationCount:  0,
+			CurrentConfirmationCount: 0,
+		}, txReceipt, nil
+	}
+
 	if bl.BlockListenerConfig.ChainTrackingMode == ffcapi.ChainTrackingModeLight {
 		// when chain head is the only thing that's being tracked, we only need to calculate the confirmation list based on the head block number
 		// get the transaction receipt only
@@ -48,13 +63,6 @@ func (bl *blockListener) ReconcileConfirmationsForTransaction(ctx context.Contex
 		if err != nil {
 			log.L(ctx).Errorf("Failed to fetch transaction receipt using tx hash %s: %v", txHash, err)
 			return nil, nil, err
-		}
-		if targetConfirmationCount == 0 {
-			return &ConfirmationUpdateResult{
-				Confirmed:                true,
-				TargetConfirmationCount:  0,
-				CurrentConfirmationCount: 0,
-			}, txReceipt, nil
 		}
 		// compare it against the chain head
 		chainHead := bl.GetHeadBlockNumber(ctx)
@@ -102,15 +110,6 @@ func (bl *blockListener) ReconcileConfirmationsForTransaction(ctx context.Contex
 func (bl *blockListener) buildConfirmationList(ctx context.Context, existingConfirmations []*ethrpc.BlockInfoJSONRPC, txBlockInfo *ethrpc.BlockInfoJSONRPC, targetConfirmationCount uint64) (*ConfirmationUpdateResult, error) {
 	// Primary objective of this algorithm is to build a contiguous, linked list of `MinimalBlockInfo` structs, starting from the transaction block and ending as far as our current knowledge of the in-memory partial canonical chain allows.
 	// Secondary objective is to report whether any fork was detected (and corrected) during this analysis
-
-	// handle confirmation count of 0 as a special case to reduce complexity of the main algorithm
-	if targetConfirmationCount == 0 {
-		reconcileResult, err := bl.handleZeroTargetConfirmationCount(ctx, txBlockInfo)
-		if reconcileResult != nil || err != nil {
-			return reconcileResult, err
-		}
-	}
-
 	// Initialize the result with the target confirmation count
 	reconcileResult := &ConfirmationUpdateResult{}
 
@@ -367,18 +366,6 @@ func (bl *blockListener) buildConfirmationQueueUsingInMemoryPartialChain(ctx con
 		nextInMemoryBlock = nextInMemoryBlock.Next()
 	}
 	return newConfirmationsWithoutTxBlock, nil
-}
-
-func (bl *blockListener) handleZeroTargetConfirmationCount(_ context.Context, txBlockInfo *ethrpc.BlockInfoJSONRPC) (*ConfirmationUpdateResult, error) {
-	bl.canonicalChainLock.RLock()
-	defer bl.canonicalChainLock.RUnlock()
-	// when target confirmation count is set to 0 as it requires no extra blocks from the in-memory partial chain
-	// we can immediately return a confirmed result
-	return &ConfirmationUpdateResult{
-		Confirmed:     true,
-		Confirmations: []*ethrpc.MinimalBlockInfo{txBlockInfo.ToMinimalBlockInfo()},
-	}, nil
-
 }
 
 func (bl *blockListener) handleTargetCountMetWithEarlyList(existingConfirmations []*ethrpc.BlockInfoJSONRPC, targetConfirmationCount uint64) *ConfirmationUpdateResult {

--- a/pkg/ethblocklistener/confirmation_reconciler_test.go
+++ b/pkg/ethblocklistener/confirmation_reconciler_test.go
@@ -175,6 +175,27 @@ func TestReconcileConfirmationsForTransaction_HeadBlockNumber_ActualCountCappedA
 	}
 }
 
+func TestReconcileConfirmationsForTransaction_HeadBlockNumber_ZeroConfirmationCount(t *testing.T) {
+	_, bl, mRPC, done := newTestBlockListener(t, headBlockNumberTestConf)
+	defer done()
+
+	mockHeadModeReceipt(t, mRPC, headModeSampleTxHash)
+	// currentChainHead is left at its zero value (behind the receipt block), to prove the
+	// chain head is never consulted when no confirmations are required
+	bl.currentChainHead = 0
+
+	result, receipt, err := bl.ReconcileConfirmationsForTransaction(context.Background(), headModeSampleTxHash, nil, 0)
+	assert.NoError(t, err)
+	if assert.NotNil(t, receipt) {
+		assert.Equal(t, uint64(1977), receipt.BlockNumber.Uint64())
+	}
+	if assert.NotNil(t, result) {
+		assert.True(t, result.Confirmed)
+		assert.Equal(t, uint64(0), result.CurrentConfirmationCount)
+		assert.Equal(t, uint64(0), result.TargetConfirmationCount)
+	}
+}
+
 func TestReconcileConfirmationsForTransaction_HeadBlockNumber_ReceiptRPCError(t *testing.T) {
 	_, bl, mRPC, done := newTestBlockListener(t, headBlockNumberTestConf)
 	defer done()
@@ -717,13 +738,17 @@ func TestHandleZeroTargetConfirmationCount_EmptyCanonicalChain(t *testing.T) {
 		ParentHash: generateTestHash(txBlockNumber - 1),
 	}
 
-	// Execute - should return error when canonical chain is empty
+	// Execute - a zero target confirmation count should confirm immediately without
+	// needing the in-memory partial chain to have caught up to the transaction block
 	result, err := bl.handleZeroTargetConfirmationCount(ctx, txBlockInfo)
 
-	// Assert - expect error with code FF23062 for empty canonical chain
-	assert.Error(t, err)
-	assert.Regexp(t, "FF23062", err.Error())
-	assert.Nil(t, result)
+	// Assert
+	assert.NoError(t, err)
+	if assert.NotNil(t, result) {
+		assert.True(t, result.Confirmed)
+		assert.Len(t, result.Confirmations, 1)
+		assert.Equal(t, txBlockNumber, uint64(result.Confirmations[0].BlockNumber))
+	}
 	mRPC.AssertExpectations(t)
 }
 
@@ -806,8 +831,8 @@ func TestBuildConfirmationList_NilConfirmationMap_ZeroConfirmationCount(t *testi
 	assert.Equal(t, txBlockNumber, uint64(confirmationUpdateResult.Confirmations[0].BlockNumber))
 }
 
-func TestBuildConfirmationList_NilConfirmationMap_ZeroConfirmationCountError(t *testing.T) {
-	// Setup
+func TestBuildConfirmationList_NilConfirmationMap_ZeroConfirmationCountChainNotCaughtUp(t *testing.T) {
+	// Setup - the in-memory partial chain has not yet caught up to the tx block
 	bl, done := newBlockListenerWithTestChain(t, 100, 5, 50, 99, []uint64{})
 	defer done()
 	ctx := context.Background()
@@ -820,11 +845,15 @@ func TestBuildConfirmationList_NilConfirmationMap_ZeroConfirmationCountError(t *
 	}
 	targetConfirmationCount := uint64(0)
 
-	// Execute
+	// Execute - a zero target confirmation count should confirm immediately, regardless
+	// of whether the in-memory partial chain has caught up to the tx block
 	confirmationUpdateResult, err := bl.buildConfirmationList(ctx, nil, txBlockInfo, targetConfirmationCount)
-	assert.Error(t, err)
-	assert.Nil(t, confirmationUpdateResult)
-	assert.Regexp(t, "FF23062", err.Error())
+	assert.NoError(t, err)
+	if assert.NotNil(t, confirmationUpdateResult) {
+		assert.True(t, confirmationUpdateResult.Confirmed)
+		assert.Len(t, confirmationUpdateResult.Confirmations, 1)
+		assert.Equal(t, txBlockNumber, uint64(confirmationUpdateResult.Confirmations[0].BlockNumber))
+	}
 }
 
 func TestBuildConfirmationList_NilConfirmationMapUnconfirmed(t *testing.T) {

--- a/pkg/ethblocklistener/confirmation_reconciler_test.go
+++ b/pkg/ethblocklistener/confirmation_reconciler_test.go
@@ -196,6 +196,33 @@ func TestReconcileConfirmationsForTransaction_HeadBlockNumber_ZeroConfirmationCo
 	}
 }
 
+func TestReconcileConfirmationsForTransaction_ZeroConfirmationCount_SkipsChainCatchup(t *testing.T) {
+	// Default (non-light) chain tracking mode with an empty canonical chain, i.e. it has
+	// not caught up to the transaction block at all. A target confirmation count of 0 should
+	// still confirm immediately from the receipt alone, without ever consulting the
+	// in-memory partial chain or fetching any block info.
+	_, bl, mRPC, done := newTestBlockListener(t)
+	defer done()
+
+	mRPC.On("CallRPC", mock.Anything, mock.Anything, "eth_getTransactionReceipt", "0x6197ef1a58a2a592bb447efb651f0db7945de21aa8048801b250bd7b7431f9b6").
+		Return(nil).
+		Run(func(args mock.Arguments) {
+			err := json.Unmarshal([]byte(sampleJSONRPCReceipt), args[1])
+			assert.NoError(t, err)
+		})
+
+	result, receipt, err := bl.ReconcileConfirmationsForTransaction(context.Background(), "0x6197ef1a58a2a592bb447efb651f0db7945de21aa8048801b250bd7b7431f9b6", nil, 0)
+	assert.NoError(t, err)
+	if assert.NotNil(t, receipt) {
+		assert.Equal(t, uint64(1977), receipt.BlockNumber.Uint64())
+	}
+	if assert.NotNil(t, result) {
+		assert.True(t, result.Confirmed)
+		assert.Equal(t, uint64(0), result.CurrentConfirmationCount)
+		assert.Equal(t, uint64(0), result.TargetConfirmationCount)
+	}
+}
+
 func TestReconcileConfirmationsForTransaction_HeadBlockNumber_ReceiptRPCError(t *testing.T) {
 	_, bl, mRPC, done := newTestBlockListener(t, headBlockNumberTestConf)
 	defer done()
@@ -719,39 +746,6 @@ func TestBuildConfirmationQueueUsingInMemoryPartialChain_EmptyCanonicalChain(t *
 	mRPC.AssertExpectations(t)
 }
 
-func TestHandleZeroTargetConfirmationCount_EmptyCanonicalChain(t *testing.T) {
-	// Setup - create a blockListener with an empty canonical chain
-	mRPC := &rpcbackendmocks.Backend{}
-	bl := &blockListener{
-		canonicalChain: list.New(), // Empty canonical chain
-		rpc:            utRPC(t, mRPC),
-	}
-	bl.blockCache, _ = lru.New(100)
-
-	ctx := context.Background()
-	txBlockNumber := uint64(100)
-	txBlockHash := generateTestHash(txBlockNumber)
-
-	txBlockInfo := &ethrpc.BlockInfoJSONRPC{
-		Number:     ethtypes.HexUint64(txBlockNumber),
-		Hash:       txBlockHash,
-		ParentHash: generateTestHash(txBlockNumber - 1),
-	}
-
-	// Execute - a zero target confirmation count should confirm immediately without
-	// needing the in-memory partial chain to have caught up to the transaction block
-	result, err := bl.handleZeroTargetConfirmationCount(ctx, txBlockInfo)
-
-	// Assert
-	assert.NoError(t, err)
-	if assert.NotNil(t, result) {
-		assert.True(t, result.Confirmed)
-		assert.Len(t, result.Confirmations, 1)
-		assert.Equal(t, txBlockNumber, uint64(result.Confirmations[0].BlockNumber))
-	}
-	mRPC.AssertExpectations(t)
-}
-
 func TestBuildConfirmationList_ChainTooShort(t *testing.T) {
 	// Setup
 	bl, done := newBlockListenerWithTestChain(t, 100, 5, 50, 99, []uint64{})
@@ -829,31 +823,6 @@ func TestBuildConfirmationList_NilConfirmationMap_ZeroConfirmationCount(t *testi
 	// The code builds a full confirmation queue from the canonical chain
 	assert.Len(t, confirmationUpdateResult.Confirmations, 1)
 	assert.Equal(t, txBlockNumber, uint64(confirmationUpdateResult.Confirmations[0].BlockNumber))
-}
-
-func TestBuildConfirmationList_NilConfirmationMap_ZeroConfirmationCountChainNotCaughtUp(t *testing.T) {
-	// Setup - the in-memory partial chain has not yet caught up to the tx block
-	bl, done := newBlockListenerWithTestChain(t, 100, 5, 50, 99, []uint64{})
-	defer done()
-	ctx := context.Background()
-	txBlockNumber := uint64(100)
-	txBlockHash := generateTestHash(txBlockNumber)
-	txBlockInfo := &ethrpc.BlockInfoJSONRPC{
-		Number:     ethtypes.HexUint64(txBlockNumber),
-		Hash:       txBlockHash,
-		ParentHash: generateTestHash(txBlockNumber - 1),
-	}
-	targetConfirmationCount := uint64(0)
-
-	// Execute - a zero target confirmation count should confirm immediately, regardless
-	// of whether the in-memory partial chain has caught up to the tx block
-	confirmationUpdateResult, err := bl.buildConfirmationList(ctx, nil, txBlockInfo, targetConfirmationCount)
-	assert.NoError(t, err)
-	if assert.NotNil(t, confirmationUpdateResult) {
-		assert.True(t, confirmationUpdateResult.Confirmed)
-		assert.Len(t, confirmationUpdateResult.Confirmations, 1)
-		assert.Equal(t, txBlockNumber, uint64(confirmationUpdateResult.Confirmations[0].BlockNumber))
-	}
 }
 
 func TestBuildConfirmationList_NilConfirmationMapUnconfirmed(t *testing.T) {
@@ -1118,35 +1087,6 @@ func TestBuildConfirmationList_NewForkAfterFirstConfirmation(t *testing.T) {
 	assert.True(t, confirmationUpdateResult.NewFork)
 	assert.True(t, confirmationUpdateResult.Confirmed)
 	assert.Len(t, confirmationUpdateResult.Confirmations, 6)
-}
-
-func TestBuildConfirmationList_NewForkAfterFirstConfirmation_ZeroConfirmationCount(t *testing.T) {
-	// Setup
-	bl, done := newBlockListenerWithTestChain(t, 100, 5, 100, 150, []uint64{})
-	defer done()
-	ctx := context.Background()
-	existingQueue := []*ethrpc.BlockInfoJSONRPC{
-		{Hash: generateTestHash(100), Number: 100, ParentHash: generateTestHash(99)},
-		{Hash: generateTestHash(101), Number: 101, ParentHash: generateTestHash(100)},
-		{Hash: generateTestHash(991 /* fork1 */), Number: 102, ParentHash: generateTestHash(101)},
-	}
-
-	txBlockNumber := uint64(100)
-	txBlockHash := generateTestHash(100)
-	txBlockInfo := &ethrpc.BlockInfoJSONRPC{
-		Number:     ethtypes.HexUint64(txBlockNumber),
-		Hash:       txBlockHash,
-		ParentHash: generateTestHash(99),
-	}
-	targetConfirmationCount := uint64(0)
-
-	// Execute
-	confirmationUpdateResult, err := bl.buildConfirmationList(ctx, existingQueue, txBlockInfo, targetConfirmationCount)
-	assert.NoError(t, err)
-	// Assert
-	assert.False(t, confirmationUpdateResult.NewFork)
-	assert.True(t, confirmationUpdateResult.Confirmed)
-	assert.Len(t, confirmationUpdateResult.Confirmations, 1)
 }
 
 func TestBuildConfirmationList_NewForkAndNoConnectionToCanonicalChain(t *testing.T) {


### PR DESCRIPTION
## Summary

- Moved the `targetConfirmationCount == 0` short-circuit to the very top of `ReconcileConfirmationsForTransaction`, before the chain-tracking-mode branch. It now returns a confirmed result as soon as the transaction receipt exists, the same way in both light and full mode.
- Removed `handleZeroTargetConfirmationCount` and the duplicate zero-count branch inside `buildConfirmationList`. Both are now unreachable since the top-level check handles every zero-confirmation call before execution gets that far.

## Why this is correct

A confirmation count of 0 means the caller has explicitly said "I don't need any blocks mined on top of the transaction's block, I only need it mined." Once a receipt comes back from the node, that condition is already satisfied by definition, full stop.

The old code additionally required the connector's own internal state to line up before it would say so:

- In light mode, it compared the receipt's block number against `currentChainHead`, which is this connector's cached view of the head, refreshed on its own polling/subscription cadence.
- In full mode, `validateChainCaughtUp` required the in-memory canonical chain (built by a separate block-listener subscription) to already contain a block at or past the transaction's block number.

Both of those are checks against connector-internal caches that lag the chain by design, not checks against the chain itself. The node that returned the receipt has already told us the transaction is mined. Gating a "0 confirmations needed" answer on an unrelated internal cache catching up doesn't add any real confirmation guarantee, it just introduces a race: right after startup, after a reorg, or under any polling lag, `FF23070` (`TransactionNotIncludedInChainHead`) or `FF23062` (`MsgInMemoryPartialChainNotCaughtUp`) can fire for a transaction that is unambiguously mined and requires zero further confirmation. That forces the caller (FireFly Transaction Manager) into pointless retries for a result that was already knowable from the receipt alone.

Consolidating the check into a single early return, instead of duplicating it once per chain-tracking mode, also means there is now one place that owns this behavior instead of two. Removing these checks for the `targetConfirmationCount == 0` path doesn't weaken confirmation semantics: there is nothing left to confirm once 0 confirmations are required. It only removes a spurious dependency on connector bookkeeping that was never part of the actual guarantee being requested.

## Test plan

- Removed `TestHandleZeroTargetConfirmationCount_EmptyCanonicalChain`, `TestBuildConfirmationList_NilConfirmationMap_ZeroConfirmationCountChainNotCaughtUp`, and `TestBuildConfirmationList_NewForkAfterFirstConfirmation_ZeroConfirmationCount`. They asserted behavior inside `handleZeroTargetConfirmationCount` / `buildConfirmationList` that no longer exists now that the zero-confirmation short-circuit lives one level up and those functions are never reached with a zero target.
- Kept `TestReconcileConfirmationsForTransaction_HeadBlockNumber_ZeroConfirmationCount` covering the light-mode path, with `currentChainHead` deliberately left behind the receipt block to prove the head is never consulted.
- Added `TestReconcileConfirmationsForTransaction_ZeroConfirmationCount_SkipsChainCatchup` covering the full (non-light) mode path with an empty canonical chain, to prove the in-memory partial chain is never consulted either.
- `go test ./pkg/ethblocklistener/...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
