### PR TITLE
Provide flexibility on the formatting options to extend the objects

### DIFF
--- a/pkg/ethrpc/ethrpc.go
+++ b/pkg/ethrpc/ethrpc.go
@@ -43,35 +43,35 @@ type TxReceiptJSONRPC struct {
 	RevertReason      ethtypes.HexBytes0xPrefix `json:"revertReason" ffstruct:"TxReceiptJSONRPC"`
 }
 
-func (txr *TxReceiptJSONRPC) MarshalFormat(jss *JSONSerializerSet, opts ...MarshalOption) (jb json.RawMessage, err error) {
-	logsArray := make([]json.RawMessage, len(txr.Logs))
+func (txr *TxReceiptJSONRPC) FormatMap() map[string]any {
+	logsArray := make([]any, len(txr.Logs))
 	for i, l := range txr.Logs {
-		if err == nil {
-			logsArray[i], err = l.MarshalFormat(jss, opts...)
-		}
+		logsArray[i] = l.FormatMap()
 	}
-	if err == nil {
-		jb, err = jss.MarshalFormattedMap(map[string]any{
-			"transactionHash":   ([]byte)(txr.TransactionHash),
-			"transactionIndex":  (*uint64)(&txr.TransactionIndex),
-			"blockHash":         ([]byte)(txr.BlockHash),
-			"blockNumber":       (*uint64)(&txr.BlockNumber),
-			"from":              (*[20]byte)(txr.From),
-			"to":                (*[20]byte)(txr.To),
-			"cumulativeGasUsed": (*big.Int)(txr.CumulativeGasUsed),
-			"effectiveGasPrice": (*big.Int)(txr.EffectiveGasPrice),
-			"gasUsed":           (*big.Int)(txr.GasUsed),
-			"contractAddress":   (*[20]byte)(txr.ContractAddress),
-			"logs":              logsArray,
-			"logsBloom":         ([]byte)(txr.LogsBloom),
-			"status":            (*uint64)(txr.Status),
-			"type":              (*uint64)(txr.Type),
-			"revertReason":      ([]byte)(txr.RevertReason),
-		}, append(opts, MarshalOption{
-			OmitNullFields: []string{"revertReason"},
-		})...)
+	m := map[string]any{
+		"transactionHash":   ([]byte)(txr.TransactionHash),
+		"transactionIndex":  (*uint64)(&txr.TransactionIndex),
+		"blockHash":         ([]byte)(txr.BlockHash),
+		"blockNumber":       (*uint64)(&txr.BlockNumber),
+		"from":              (*[20]byte)(txr.From),
+		"to":                (*[20]byte)(txr.To),
+		"cumulativeGasUsed": (*big.Int)(txr.CumulativeGasUsed),
+		"effectiveGasPrice": (*big.Int)(txr.EffectiveGasPrice),
+		"gasUsed":           (*big.Int)(txr.GasUsed),
+		"contractAddress":   (*[20]byte)(txr.ContractAddress),
+		"logs":              logsArray,
+		"logsBloom":         ([]byte)(txr.LogsBloom),
+		"status":            (*uint64)(txr.Status),
+		"type":              (*uint64)(txr.Type),
 	}
-	return jb, err
+	if txr.RevertReason != nil {
+		m["revertReason"] = ([]byte)(txr.RevertReason)
+	}
+	return m
+}
+
+func (txr *TxReceiptJSONRPC) MarshalFormat(jss *JSONSerializerSet, opts ...MarshalOption) (json.RawMessage, error) {
+	return jss.MarshalFormattedMap(txr.FormatMap(), opts...)
 }
 
 // TxInfoJSONRPC is the transaction info obtained over JSON/RPC from the ethereum client, with input data
@@ -96,30 +96,38 @@ type TxInfoJSONRPC struct {
 	S                    *ethtypes.HexInteger      `json:"s" ffstruct:"TxInfoJSONRPC"`
 }
 
-func (txi *TxInfoJSONRPC) MarshalFormat(jss *JSONSerializerSet, opts ...MarshalOption) (_ json.RawMessage, err error) {
-	optsWithNulls := make([]MarshalOption, 0, len(opts)+1)
-	optsWithNulls = append(optsWithNulls, MarshalOption{OmitNullFields: []string{"maxFeePerGas", "maxPriorityFeePerGas", "gasPrice"}})
-	optsWithNulls = append(optsWithNulls, opts...)
-	return jss.MarshalFormattedMap(map[string]any{
-		"blockHash":            ([]byte)(txi.BlockHash),
-		"blockNumber":          (*uint64)(&txi.BlockNumber),
-		"chainId":              (*big.Int)(txi.ChainID),
-		"from":                 (*[20]byte)(txi.From),
-		"gas":                  (*big.Int)(txi.Gas),
-		"gasPrice":             (*big.Int)(txi.GasPrice),
-		"maxFeePerGas":         (*big.Int)(txi.MaxFeePerGas),
-		"maxPriorityFeePerGas": (*big.Int)(txi.MaxPriorityFeePerGas),
-		"hash":                 ([]byte)(txi.Hash),
-		"input":                ([]byte)(txi.Input),
-		"nonce":                (*big.Int)(txi.Nonce),
-		"to":                   (*[20]byte)(txi.To),
-		"transactionIndex":     (*uint64)(txi.TransactionIndex),
-		"type":                 (*uint64)(txi.Type),
-		"value":                (*big.Int)(txi.Value),
-		"v":                    (*big.Int)(txi.V),
-		"r":                    (*big.Int)(txi.R),
-		"s":                    (*big.Int)(txi.S),
-	}, optsWithNulls...)
+func (txi *TxInfoJSONRPC) FormatMap() map[string]any {
+	m := map[string]any{
+		"blockHash":        ([]byte)(txi.BlockHash),
+		"blockNumber":      (*uint64)(&txi.BlockNumber),
+		"chainId":          (*big.Int)(txi.ChainID),
+		"from":             (*[20]byte)(txi.From),
+		"gas":              (*big.Int)(txi.Gas),
+		"hash":             ([]byte)(txi.Hash),
+		"input":            ([]byte)(txi.Input),
+		"nonce":            (*big.Int)(txi.Nonce),
+		"to":               (*[20]byte)(txi.To),
+		"transactionIndex": (*uint64)(txi.TransactionIndex),
+		"type":             (*uint64)(txi.Type),
+		"value":            (*big.Int)(txi.Value),
+		"v":                (*big.Int)(txi.V),
+		"r":                (*big.Int)(txi.R),
+		"s":                (*big.Int)(txi.S),
+	}
+	if txi.GasPrice != nil {
+		m["gasPrice"] = (*big.Int)(txi.GasPrice)
+	}
+	if txi.MaxFeePerGas != nil {
+		m["maxFeePerGas"] = (*big.Int)(txi.MaxFeePerGas)
+	}
+	if txi.MaxPriorityFeePerGas != nil {
+		m["maxPriorityFeePerGas"] = (*big.Int)(txi.MaxPriorityFeePerGas)
+	}
+	return m
+}
+
+func (txi *TxInfoJSONRPC) MarshalFormat(jss *JSONSerializerSet, opts ...MarshalOption) (json.RawMessage, error) {
+	return jss.MarshalFormattedMap(txi.FormatMap(), opts...)
 }
 
 // See https://ethereum.org/hr/developers/docs/apis/json-rpc/#eth_newfilter
@@ -144,12 +152,12 @@ type LogJSONRPC struct {
 	Topics           []ethtypes.HexBytes0xPrefix `json:"topics" ffstruct:"LogJSONRPC"`
 }
 
-func (l *LogJSONRPC) MarshalFormat(jss *JSONSerializerSet, opts ...MarshalOption) (_ json.RawMessage, err error) {
+func (l *LogJSONRPC) FormatMap() map[string]any {
 	topicsArray := make([]any, len(l.Topics))
 	for i, t := range l.Topics {
 		topicsArray[i] = ([]byte)(t)
 	}
-	return jss.MarshalFormattedMap(map[string]any{
+	return map[string]any{
 		"removed":          l.Removed,
 		"logIndex":         (*uint64)(&l.LogIndex),
 		"transactionIndex": (*uint64)(&l.TransactionIndex),
@@ -159,7 +167,11 @@ func (l *LogJSONRPC) MarshalFormat(jss *JSONSerializerSet, opts ...MarshalOption
 		"address":          (*[20]byte)(l.Address),
 		"data":             ([]byte)(l.Data),
 		"topics":           topicsArray,
-	}, opts...)
+	}
+}
+
+func (l *LogJSONRPC) MarshalFormat(jss *JSONSerializerSet, opts ...MarshalOption) (json.RawMessage, error) {
+	return jss.MarshalFormattedMap(l.FormatMap(), opts...)
 }
 
 // BlockInfoJSONRPC are the info fields we parse from the JSON/RPC response, and cache
@@ -174,19 +186,23 @@ type BlockInfoJSONRPC struct {
 	Transactions  []ethtypes.HexBytes0xPrefix `json:"transactions" ffstruct:"BlockInfoJSONRPC"`
 }
 
-func (bi *BlockInfoJSONRPC) MarshalFormat(jss *JSONSerializerSet, opts ...MarshalOption) (_ json.RawMessage, err error) {
+func (bi *BlockInfoJSONRPC) FormatMap() map[string]any {
 	txnArray := make([]any, len(bi.Transactions))
 	for i, t := range bi.Transactions {
 		txnArray[i] = ([]byte)(t)
 	}
-	return jss.MarshalFormattedMap(map[string]any{
+	return map[string]any{
 		"number":       (*uint64)(&bi.Number),
 		"hash":         ([]byte)(bi.Hash),
 		"parentHash":   ([]byte)(bi.ParentHash),
 		"timestamp":    (*uint64)(&bi.Timestamp),
 		"logsBloom":    ([]byte)(bi.LogsBloom),
 		"transactions": txnArray,
-	}, opts...)
+	}
+}
+
+func (bi *BlockInfoJSONRPC) MarshalFormat(jss *JSONSerializerSet, opts ...MarshalOption) (json.RawMessage, error) {
+	return jss.MarshalFormattedMap(bi.FormatMap(), opts...)
 }
 
 func (bi *BlockInfoJSONRPC) Equal(bi2 *BlockInfoJSONRPC) bool {
@@ -249,7 +265,7 @@ type BlockHeaderJSONRPC struct {
 	Uncles           []ethtypes.HexBytes0xPrefix `json:"uncles" ffstruct:"BlockInfoJSONRPC"`
 }
 
-func (b *BlockHeaderJSONRPC) getFormatMap() map[string]any {
+func (b *BlockHeaderJSONRPC) FormatMap() map[string]any {
 	unclesArray := make([]any, len(b.Uncles))
 	for i, uncle := range b.Uncles {
 		unclesArray[i] = ([]byte)(uncle)
@@ -326,27 +342,30 @@ func (b *EVMBlockWithTransactionsJSONRPC) ToBlockInfo(includeLogsBloom bool) *Bl
 	return bi
 }
 
-func (b *EVMBlockWithTxHashesJSONRPC) MarshalFormat(jss *JSONSerializerSet, opts ...MarshalOption) (_ json.RawMessage, err error) {
+func (b *EVMBlockWithTxHashesJSONRPC) FormatMap() map[string]any {
 	txnHashArray := make([]any, len(b.Transactions))
 	for i, t := range b.Transactions {
 		txnHashArray[i] = ([]byte)(t)
 	}
-	formatMap := b.BlockHeaderJSONRPC.getFormatMap()
+	formatMap := b.BlockHeaderJSONRPC.FormatMap()
 	formatMap["transactions"] = txnHashArray
-	return jss.MarshalFormattedMap(formatMap, opts...)
+	return formatMap
 }
 
-func (b *EVMBlockWithTransactionsJSONRPC) MarshalFormat(jss *JSONSerializerSet, opts ...MarshalOption) (jb json.RawMessage, err error) {
-	txnsArray := make([]json.RawMessage, len(b.Transactions))
-	for i, l := range b.Transactions {
-		if err == nil {
-			txnsArray[i], err = l.MarshalFormat(jss, opts...)
-		}
+func (b *EVMBlockWithTxHashesJSONRPC) MarshalFormat(jss *JSONSerializerSet, opts ...MarshalOption) (json.RawMessage, error) {
+	return jss.MarshalFormattedMap(b.FormatMap(), opts...)
+}
+
+func (b *EVMBlockWithTransactionsJSONRPC) FormatMap() map[string]any {
+	txnsArray := make([]any, len(b.Transactions))
+	for i, t := range b.Transactions {
+		txnsArray[i] = t.FormatMap()
 	}
-	if err == nil {
-		formatMap := b.BlockHeaderJSONRPC.getFormatMap()
-		formatMap["transactions"] = txnsArray
-		jb, err = jss.MarshalFormattedMap(formatMap, opts...)
-	}
-	return jb, err
+	formatMap := b.BlockHeaderJSONRPC.FormatMap()
+	formatMap["transactions"] = txnsArray
+	return formatMap
+}
+
+func (b *EVMBlockWithTransactionsJSONRPC) MarshalFormat(jss *JSONSerializerSet, opts ...MarshalOption) (json.RawMessage, error) {
+	return jss.MarshalFormattedMap(b.FormatMap(), opts...)
 }

--- a/pkg/ethrpc/ethrpc_test.go
+++ b/pkg/ethrpc/ethrpc_test.go
@@ -139,6 +139,57 @@ func TestFormatTransaction(t *testing.T) {
 	require.JSONEq(t, sampleTransaction, string(ethSerialized))
 }
 
+func TestFormatTransactionEIP1559(t *testing.T) {
+	var txInfo TxInfoJSONRPC
+	err := json.Unmarshal([]byte(sampleTransaction), &txInfo)
+	require.NoError(t, err)
+	txInfo.GasPrice = nil
+	txInfo.MaxFeePerGas = ethtypes.NewHexInteger64(1000)
+	txInfo.MaxPriorityFeePerGas = ethtypes.NewHexInteger64(10)
+
+	jss := testJSONSerializationSet(t, "number=hex")
+
+	ethSerialized, err := txInfo.MarshalFormat(jss)
+	fmt.Println((string)(ethSerialized))
+	require.NoError(t, err)
+
+	var genericMap map[string]any
+	err = json.Unmarshal(ethSerialized, &genericMap)
+	require.NoError(t, err)
+	_, hasGasPrice := genericMap["gasPrice"]
+	require.False(t, hasGasPrice)
+	require.Equal(t, "0x3e8", genericMap["maxFeePerGas"])
+	require.Equal(t, "0xa", genericMap["maxPriorityFeePerGas"])
+}
+
+func TestFormatLog(t *testing.T) {
+	var receipt TxReceiptJSONRPC
+	err := json.Unmarshal([]byte(sampleReceipt), &receipt)
+	require.NoError(t, err)
+	require.Len(t, receipt.Logs, 1)
+
+	jss := testJSONSerializationSet(t, "number=hex&pretty=true")
+
+	ethSerialized, err := receipt.Logs[0].MarshalFormat(jss)
+	fmt.Println((string)(ethSerialized))
+	require.NoError(t, err)
+	require.JSONEq(t, `{
+		"address": "0xaa75b5001274491c0985ba1012b09dfc02d9675d",
+		"topics": [
+			"0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+			"0x00000000000000000000000003a85df677b2aa0f7cccc942242ee900de505ce8",
+			"0x000000000000000000000000af5ce0b6c5745e49b4292794496bf2a08b97608b"
+		],
+		"data": "0x00000000000000000000000000000000000000000000000246ddf97976680000",
+		"blockNumber": "0xe5f2",
+		"transactionHash": "0x6431a7fc56e24319bb431ed3040d77d1a7b54add9207266c19df6fc53961da99",
+		"transactionIndex": "0x0",
+		"blockHash": "0xd33367228e0a0e3667c910c7d92d3f6e724e2b6e2f671b28823a22f82597d023",
+		"logIndex": "0x0",
+		"removed": false
+	}`, string(ethSerialized))
+}
+
 func TestFormatReceipt(t *testing.T) {
 	var receipt TxReceiptJSONRPC
 	err := json.Unmarshal([]byte(sampleReceipt), &receipt)

--- a/pkg/ethrpc/jsonformatoptions_test.go
+++ b/pkg/ethrpc/jsonformatoptions_test.go
@@ -272,15 +272,20 @@ func TestFormatStructVariation(t *testing.T) {
 	jss := testJSONSerializationSet(t, "pretty=true")
 
 	ethSerialized, err := jss.MarshalFormattedMap(map[string]any{
-		"float1": big.NewFloat(123.456),
+		"float1":   big.NewFloat(123.456),
+		"omitted":  (*big.Int)(nil),
+		"retained": (*big.Int)(nil),
 		"nested": map[string]any{
 			"float2": big.NewFloat(234.567),
 		},
+	}, MarshalOption{
+		OmitNullFields: []string{"omitted"},
 	})
 	fmt.Println((string)(ethSerialized))
 	require.NoError(t, err)
 	require.JSONEq(t, `{
 		"float1": "123.456",
+		"retained": null,
 		"nested": {
 			"float2": "234.567"
 		}


### PR DESCRIPTION
We have great JSON formatting features for a number of Ethereum JSON/RPC objects, but we force you to take the serialization part on the boundary of this module.

This PR proposes giving the flexibility to defer that serialization of the map so it can be extended.